### PR TITLE
Only handle hashes with a '/' when using createHashHistory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 ## [v2.0.0-rc3]
 > Feb 3, 2016
 
+- `createHashHistory` does not enforce a '/' at the beginning of the hash anymore
+
 - **Bugfix:** Don't convert same-path `PUSH` to `REPLACE` when `location.state` changes ([#179])
 - **Bugfix:** Re-enable browser history on Chrome iOS ([#208])
 - **Bugfix:** Properly support location descriptors in `history.createLocation` ([#200])

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -15,8 +15,8 @@ import describeGo from './describeGo'
 
 describe('hash history', function () {
   beforeEach(function () {
-    if (window.location.hash !== '')
-      window.location.hash = ''
+    if (window.location.hash !== '/')
+      window.location.hash = '/'
   })
 
   describeInitialLocation(createHashHistory)

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -7,21 +7,6 @@ import { addEventListener, removeEventListener, getHashPath, replaceHashPath, su
 import { saveState, readState } from './DOMStateStorage'
 import createDOMHistory from './createDOMHistory'
 
-function isAbsolutePath(path) {
-  return typeof path === 'string' && path.charAt(0) === '/'
-}
-
-function ensureSlash() {
-  const path = getHashPath()
-
-  if (isAbsolutePath(path))
-    return true
-
-  replaceHashPath('/' + path)
-
-  return false
-}
-
 function addQueryStringValueToPath(path, key, value) {
   return path + (path.indexOf('?') === -1 ? '?' : '&') + `${key}=${value}`
 }
@@ -74,15 +59,11 @@ function createHashHistory(options={}) {
 
   function startHashChangeListener({ transitionTo }) {
     function hashChangeListener() {
-      if (!ensureSlash())
-        return // Always make sure hashes are preceeded with a /.
-
       transitionTo(
         getCurrentLocation()
       )
     }
 
-    ensureSlash()
     addEventListener(window, 'hashchange', hashChangeListener)
 
     return function () {


### PR DESCRIPTION
This PR adds the ability to ignore hash changes when using createHashHistory().

Example: 
```javascript
function ignorePath(path){
   return path.startWidth('ignore-me');
}
let history = createHistory({'ignorePath': ignorePath});
```

We have the issue, that the hashChangeListener calls ensureSlash for hashes, not handled by the history.