### PR TITLE
added hashbang support

### DIFF
--- a/docs/HashHistoryCaveats.md
+++ b/docs/HashHistoryCaveats.md
@@ -16,6 +16,11 @@ let history = createHistory({
 let history = createHistory({
   queryKey: false
 })
+
+// Enable hashbang URLs
+let history = createHistory({
+  hashbang: true
+})
 ```
 
 One other thing to keep in mind when using hash history is that you cannot also use `window.location.hash` as it was originally intended, to link an anchor point within your HTML document.

--- a/docs/HashHistoryCaveats.md
+++ b/docs/HashHistoryCaveats.md
@@ -19,8 +19,14 @@ let history = createHistory({
 
 // Use custom URL transformations, for example for hashbang support
 let history = createHistory({
-  transformPath: (path) =>
-    path.indexOf('!') !== 0 ? `!${path}` : path
+  transformPath: (path, encode) => {
+    // if encoding, we transform the path to our hash value
+    if (encode)
+      return path.indexOf('!') !== 0 ? `!${path}` : path
+
+    // when decoding, we transform the hash value back into the original path
+    return path.substring(1)
+  }
 })
 ```
 

--- a/docs/HashHistoryCaveats.md
+++ b/docs/HashHistoryCaveats.md
@@ -17,9 +17,10 @@ let history = createHistory({
   queryKey: false
 })
 
-// Enable hashbang URLs
+// Use custom URL transformations, for example for hashbang support
 let history = createHistory({
-  hashbang: true
+  transformPath: (path) =>
+    path.indexOf('!') !== 0 ? `!${path}` : path
 })
 ```
 

--- a/modules/HashProtocol.js
+++ b/modules/HashProtocol.js
@@ -64,9 +64,6 @@ export const startListener = (listener, queryKey, transform) => {
   const handleHashChange = () => {
     const transformedPath = transform(getHashPath(), true)
 
-    if (transformedPath === false)
-      return // Invalid path
-
     replaceHashPath(transformedPath)
 
     const currentLocation = getCurrentLocation(queryKey, transform)
@@ -79,9 +76,10 @@ export const startListener = (listener, queryKey, transform) => {
     listener(currentLocation)
   }
 
-  const transformedPath = transform(getHashPath(), true)
+  const path = getHashPath()
+  const transformedPath = transform(path, true)
 
-  if (typeof transformedPath === 'string')
+  if (path !== transformedPath)
     replaceHashPath(transformedPath)
 
   addEventListener(window, HashChangeEvent, handleHashChange)

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -27,15 +27,13 @@ describe('hash history', () => {
   it('knows how to make hrefs with a custom transformPath function', () => {
     const history = createHashHistory({
       transformPath: (path, encode) => {
-        // if encoding, add an exclamation mark for hashbang support
         if (encode)
-          return path.indexOf('!') !== 0 ? `!${path}` : path
+          return path.indexOf('/prefix') !== 0 ? `/prefix${path}` : path
 
-        // when decoding, remove the exclamation mark
-        return path.substring(1)
+        return path.substring(7)
       }
     })
-    expect(history.createHref('/a/path')).toEqual('#!/a/path')
+    expect(history.createHref('/a/path')).toEqual('#/prefix/a/path')
   })
 
   describeListen(createHashHistory)

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -23,9 +23,10 @@ describe('hash history', () => {
     expect(history.createHref('/a/path')).toEqual('#/a/path')
   })
 
-  it('knows how to make hrefs with an escaped fragment', () => {
+  it('knows how to make hrefs with a custom transformPath function', () => {
     const history = createHashHistory({
-      hashbang: true,
+      transformPath: (path) =>
+        path.indexOf('!') !== 0 ? `!${path}` : path
     })
     expect(history.createHref('/a/path')).toEqual('#!/a/path')
   })

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -23,6 +23,13 @@ describe('hash history', () => {
     expect(history.createHref('/a/path')).toEqual('#/a/path')
   })
 
+  it('knows how to make hrefs with an escaped fragment', () => {
+    const history = createHashHistory({
+      hashbang: true,
+    })
+    expect(history.createHref('/a/path')).toEqual('#!/a/path')
+  })
+
   describeListen(createHashHistory)
   describeInitialLocation(createHashHistory)
   describeTransitions(createHashHistory)

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -43,7 +43,6 @@ describe('hash history', () => {
   describeReplace(createHashHistory)
   describeBasename(createHashHistory)
   describeQueries(createHashHistory)
-  describeTransformPath(createHashHistory)
 
   if (supportsHistory()) {
     describePopState(createHashHistory)
@@ -54,10 +53,12 @@ describe('hash history', () => {
   }
 
   if (supportsHistory() && supportsGoWithoutReloadUsingHash()) {
+    describeTransformPath(createHashHistory)
     describeGo(createHashHistory)
     describeQueryKey(createHashHistory)
   } else {
     describe.skip(null, () => {
+      describeTransformPath(createHashHistory)
       describeGo(createHashHistory)
       describeQueryKey(createHashHistory)
     })

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -6,6 +6,7 @@ import describeInitialLocation from './describeInitialLocation'
 import describeTransitions from './describeTransitions'
 import describePush from './describePush'
 import describeReplace from './describeReplace'
+import describeTransformPath from './describeTransformPath'
 import describePopState from './describePopState'
 import describeQueryKey from './describeQueryKey'
 import describeBasename from './describeBasename'
@@ -25,8 +26,14 @@ describe('hash history', () => {
 
   it('knows how to make hrefs with a custom transformPath function', () => {
     const history = createHashHistory({
-      transformPath: (path) =>
-        path.indexOf('!') !== 0 ? `!${path}` : path
+      transformPath: (path, encode) => {
+        // if encoding, add an exclamation mark for hashbang support
+        if (encode)
+          return path.indexOf('!') !== 0 ? `!${path}` : path
+
+        // when decoding, remove the exclamation mark
+        return path.substring(1)
+      }
     })
     expect(history.createHref('/a/path')).toEqual('#!/a/path')
   })
@@ -38,6 +45,7 @@ describe('hash history', () => {
   describeReplace(createHashHistory)
   describeBasename(createHashHistory)
   describeQueries(createHashHistory)
+  describeTransformPath(createHashHistory)
 
   if (supportsHistory()) {
     describePopState(createHashHistory)

--- a/modules/__tests__/describeTransformPath.js
+++ b/modules/__tests__/describeTransformPath.js
@@ -1,0 +1,112 @@
+import expect from 'expect'
+import { PUSH, POP } from '../Actions'
+import execSteps from './execSteps'
+
+const describeTransformPath = (createHistory) => {
+  describe('transformPath option', () => {
+    let history
+    beforeEach(() => {
+      history = createHistory({
+        transformPath: (path, encode) => {
+          // if encoding, add an exclamation mark for hashbang support
+          if (encode)
+            return path.indexOf('!') !== 0 ? `!${path}` : path
+
+          // when decoding, remove the exclamation mark
+          return path.substring(1)
+        }
+      })
+    })
+
+    // Some browsers need a little time to reflect the
+    // hashchange before starting the next test
+    afterEach(done => setTimeout(done, 100))
+
+    describe('back', () => {
+      it('calls change listeners with the previous location', (done) => {
+        const steps = [
+          (location) => {
+            expect(location.pathname).toEqual('/')
+            expect(location.search).toEqual('')
+            expect(location.state).toBe(undefined)
+            expect(location.action).toEqual(POP)
+            expect(location.key).toBe(null)
+
+            history.push({
+              pathname: '/home',
+              search: '?the=query',
+              state: { the: 'state' }
+            })
+          },
+          (location) => {
+            expect(location.pathname).toEqual('/home')
+            expect(location.search).toEqual('?the=query')
+            expect(location.state).toEqual({ the: 'state' })
+            expect(location.action).toEqual(PUSH)
+            expect(location.key).toExist()
+
+            history.goBack()
+          },
+          (location) => {
+            expect(location.pathname).toEqual('/')
+            expect(location.search).toEqual('')
+            expect(location.state).toBe(undefined)
+            expect(location.action).toEqual(POP)
+            expect(location.key).toBe(null)
+          }
+        ]
+
+        execSteps(steps, history, done)
+      })
+    })
+
+    describe('forward', () => {
+      it('calls change listeners with the next location', (done) => {
+        const steps = [
+          (location) => {
+            expect(location.pathname).toEqual('/')
+            expect(location.search).toEqual('')
+            expect(location.state).toBe(undefined)
+            expect(location.action).toEqual(POP)
+            expect(location.key).toBe(null)
+
+            history.push({
+              pathname: '/home',
+              search: '?the=query',
+              state: { the: 'state' }
+            })
+          },
+          (location) => {
+            expect(location.pathname).toEqual('/home')
+            expect(location.search).toEqual('?the=query')
+            expect(location.state).toEqual({ the: 'state' })
+            expect(location.action).toEqual(PUSH)
+            expect(location.key).toExist()
+
+            history.goBack()
+          },
+          (location) => {
+            expect(location.pathname).toEqual('/')
+            expect(location.search).toEqual('')
+            expect(location.state).toBe(undefined)
+            expect(location.action).toEqual(POP)
+            expect(location.key).toBe(null)
+
+            history.goForward()
+          },
+          (location) => {
+            expect(location.pathname).toEqual('/home')
+            expect(location.search).toEqual('?the=query')
+            expect(location.state).toEqual({ the: 'state' })
+            expect(location.action).toEqual(POP)
+            expect(location.key).toExist()
+          }
+        ]
+
+        execSteps(steps, history, done)
+      })
+    })
+  })
+}
+
+export default describeTransformPath

--- a/modules/__tests__/describeTransformPath.js
+++ b/modules/__tests__/describeTransformPath.js
@@ -8,12 +8,10 @@ const describeTransformPath = (createHistory) => {
     beforeEach(() => {
       history = createHistory({
         transformPath: (path, encode) => {
-          // if encoding, add an exclamation mark for hashbang support
           if (encode)
-            return path.indexOf('!') !== 0 ? `!${path}` : path
+            return path.indexOf('/prefix') !== 0 ? `/prefix${path}` : path
 
-          // when decoding, remove the exclamation mark
-          return path.substring(1)
+          return path.substring(7)
         }
       })
     })

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -30,13 +30,13 @@ const createHashHistory = (options = {}) => {
     transformPath = ensureSlash
 
   const getCurrentLocation = () =>
-    HashProtocol.getCurrentLocation(queryKey)
+    HashProtocol.getCurrentLocation(queryKey, transformPath)
 
   const pushLocation = (location) =>
-    HashProtocol.pushLocation(location, queryKey)
+    HashProtocol.pushLocation(location, queryKey, transformPath)
 
   const replaceLocation = (location) =>
-    HashProtocol.replaceLocation(location, queryKey)
+    HashProtocol.replaceLocation(location, queryKey, transformPath)
 
   const history = createHistory({
     getUserConfirmation, // User may override in options
@@ -87,7 +87,7 @@ const createHashHistory = (options = {}) => {
   }
 
   const createHref = (path) =>
-    '#' + transformPath(history.createHref(path))
+    '#' + transformPath(history.createHref(path), true)
 
   return {
     ...history,

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -13,7 +13,7 @@ const createHashHistory = (options = {}) => {
     'Hash history needs a DOM'
   )
 
-  let { queryKey } = options
+  let { queryKey, transformPath } = options
 
   warning(
     queryKey !== false,
@@ -21,10 +21,13 @@ const createHashHistory = (options = {}) => {
     'use location state if you don\'t want a key in your URL query string'
   )
 
+  const { getUserConfirmation, ensureSlash } = HashProtocol
+
   if (typeof queryKey !== 'string')
     queryKey = DefaultQueryKey
 
-  const { getUserConfirmation } = HashProtocol
+  if (typeof transformPath !== 'function')
+    transformPath = ensureSlash
 
   const getCurrentLocation = () =>
     HashProtocol.getCurrentLocation(queryKey)
@@ -50,7 +53,8 @@ const createHashHistory = (options = {}) => {
     if (++listenerCount === 1)
       stopListener = HashProtocol.startListener(
         history.transitionTo,
-        queryKey
+        queryKey,
+        transformPath
       )
 
     const unlisten = before
@@ -82,10 +86,8 @@ const createHashHistory = (options = {}) => {
     history.go(n)
   }
 
-  const hash = options.hashbang ? '#!' : '#'
-
   const createHref = (path) =>
-    hash + history.createHref(path)
+    '#' + transformPath(history.createHref(path))
 
   return {
     ...history,

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -82,8 +82,10 @@ const createHashHistory = (options = {}) => {
     history.go(n)
   }
 
+  const hash = options.hashbang ? '#!' : '#'
+
   const createHref = (path) =>
-    '#' + history.createHref(path)
+    hash + history.createHref(path)
 
   return {
     ...history,


### PR DESCRIPTION
I've added an option `hashbang` to the `createHashHistory` method to allow for optional hash-bang (`#!`) urls. This is part of a fix for reactjs/react-router#601. See the updated documentation for details.