### PR TITLE
Use es2015-loose instead of es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-1": "^6.5.0",
     "eslint": "^2.13.1",
     "eslint-plugin-import": "^1.8.1",
@@ -70,7 +71,7 @@
   ],
   "babel": {
     "presets": [
-      "es2015",
+      "es2015-loose",
       "stage-1"
     ],
     "plugins": [


### PR DESCRIPTION
This drops both the unminified and the minified UMD builds by 1 kB or so, and probably makes code run marginally faster.