### PR TITLE
Fix basename being case sensitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [HEAD]
+
+- **Bugfix:** Fix basename being case sensitive ([#413])
+
 ## [v3.2.0]
 > Sep 1, 2016
 

--- a/modules/useBasename.js
+++ b/modules/useBasename.js
@@ -11,7 +11,7 @@ const useBasename = (createHistory) =>
         return location
 
       if (basename && location.basename == null) {
-        if (location.pathname.indexOf(basename) === 0) {
+        if (location.pathname.toLowerCase().indexOf(basename.toLowerCase()) === 0) {
           location.pathname = location.pathname.substring(basename.length)
           location.basename = basename
 


### PR DESCRIPTION
I'm using `react-router` v3 with SSR, using `match` both on client and server.

When I use `match` on client, it tries to create location using `history.getCurrentLocation`: https://github.com/ReactTraining/react-router/blob/master/modules/match.js#L34

In this scenario, the basename is case sensitive. If it's not typed exactly by the user, the url won't be split between `pathname` and `basename`.

Here's an example: let's say I configured basename to be `/MyBaseName`. If the user types `http://myserver.com/mybasename` it won't match. It's the same if I configure basename all lowercase and the user type any char uppercase. Also, it's not fair to ask a mobile user to type each character with the exact case, they simple won't.

This is the only scenario where I found routes to be case sensitive, so I think it's a bug.

Please help me if my thoughts are wrong 😄 