### PR TITLE
Remove trailing slash from basename

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -7,6 +7,12 @@ export const stripLeadingSlash = (path) =>
 export const stripPrefix = (path, prefix) =>
   path.indexOf(prefix) === 0 ? path.substr(prefix.length) : path
 
+const stripTrailingSlash = (path) =>
+  path.charAt(path.length-1) === '/' ? path.slice(0, -1) : path
+
+export const cleanBasename = basename =>
+  basename ? stripTrailingSlash(addLeadingSlash(basename)) : ''
+
 export const parsePath = (path) => {
   let pathname = path || '/'
   let search = ''

--- a/modules/__tests__/CreateHref-test.js
+++ b/modules/__tests__/CreateHref-test.js
@@ -37,6 +37,23 @@ describe('a browser history', () => {
       expect(href).toEqual('/the/base/the/path?the=query#the-hash')
     })
   })
+
+  describe('with a bad basename', () => {
+    let history
+    beforeEach(() => {
+      history = createBrowserHistory({ basename: '/the/bad/base/' })
+    })
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      })
+
+      expect(href).toEqual('/the/bad/base/the/path?the=query#the-hash')
+    })
+  })
 })
 
 describe('a hash history', () => {
@@ -88,6 +105,38 @@ describe('a hash history', () => {
       })
 
       expect(href).toEqual('#!/the/path?the=query#the-hash')
+    })
+  })
+
+  describe('with a basename', () => {
+    let history
+    beforeEach(() => {
+      history = createHashHistory({ basename: '/the/base' })
+    })
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query'
+      })
+
+      expect(href).toEqual('#/the/base/the/path?the=query')
+    })
+  })
+
+  describe('with a bad basename', () => {
+    let history
+    beforeEach(() => {
+      history = createHashHistory({ basename: '/the/bad/base/' })
+    })
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query'
+      })
+
+      expect(href).toEqual('#/the/bad/base/the/path?the=query')
     })
   })
 })

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -1,7 +1,12 @@
 import warning from 'warning'
 import invariant from 'invariant'
 import { createLocation } from './LocationUtils'
-import { addLeadingSlash, stripPrefix, parsePath, createPath } from './PathUtils'
+import {
+  stripPrefix,
+  parsePath,
+  createPath,
+  cleanBasename
+} from './PathUtils'
 import createTransitionManager from './createTransitionManager'
 import { canUseDOM } from './ExecutionEnvironment'
 import {
@@ -45,7 +50,7 @@ const createBrowserHistory = (props = {}) => {
     getUserConfirmation = getConfirmation,
     keyLength = 6
   } = props
-  const basename = props.basename ? addLeadingSlash(props.basename) : ''
+  const basename = cleanBasename(props.basename)
 
   const getDOMLocation = (historyState) => {
     const { key, state } = (historyState || {})

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -1,7 +1,14 @@
 import warning from 'warning'
 import invariant from 'invariant'
 import { createLocation, locationsAreEqual } from './LocationUtils'
-import { addLeadingSlash, stripLeadingSlash, stripPrefix, parsePath, createPath } from './PathUtils'
+import {
+  addLeadingSlash,
+  stripLeadingSlash,
+  stripPrefix,
+  parsePath,
+  createPath,
+  cleanBasename
+} from './PathUtils'
 import createTransitionManager from './createTransitionManager'
 import { canUseDOM } from './ExecutionEnvironment'
 import {
@@ -60,7 +67,7 @@ const createHashHistory = (props = {}) => {
     getUserConfirmation = getConfirmation,
     hashType = 'slash'
   } = props
-  const basename = props.basename ? addLeadingSlash(props.basename) : ''
+  const basename = cleanBasename(props.basename)
 
   const { encodePath, decodePath } = HashPathCoders[hashType]
 


### PR DESCRIPTION
If the basename passed to a history has a trailing slash, it is removed.

```js
'' => ''
'/' => ''
'/nested/site' => '/nested/site'
'/nested/site/' => '/nested/site'
```

I think that this is the best solution. If basenames with a trailing slash are left as they are provided, then that complicates both a) joining paths and b) stripping the prefix when getting the location from `window.location`. By removing the trailing slash, path joining is simple and you don't have to worry about creating a "relative" location in `getDOMLocation`.