### PR TITLE
Convert slash basename to empty string

### DIFF
--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -54,6 +54,23 @@ describe('a browser history', () => {
       expect(href).toEqual('/the/bad/base/the/path?the=query#the-hash')
     })
   })
+
+  describe('with a slash basename', () => {
+    let history
+    beforeEach(() => {
+      history = createBrowserHistory({ basename: '/' })
+    })
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      })
+
+      expect(href).toEqual('/the/path?the=query#the-hash')
+    })
+  })
 })
 
 describe('a hash history', () => {
@@ -137,6 +154,22 @@ describe('a hash history', () => {
       })
 
       expect(href).toEqual('#/the/bad/base/the/path?the=query')
+    })
+  })
+
+  describe('with a slash basename', () => {
+    let history
+    beforeEach(() => {
+      history = createHashHistory({ basename: '/' })
+    })
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query'
+      })
+
+      expect(href).toEqual('#/the/path?the=query')
     })
   })
 })

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -51,7 +51,7 @@ const createBrowserHistory = (props = {}) => {
     getUserConfirmation = getConfirmation,
     keyLength = 6
   } = props
-  const basename = props.basename ? addLeadingSlash(stripTrailingSlash(props.basename)) : ''
+  const basename = props.basename ? stripTrailingSlash(addLeadingSlash(props.basename)) : ''
 
   const getDOMLocation = (historyState) => {
     const { key, state } = (historyState || {})

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -67,7 +67,7 @@ const createHashHistory = (props = {}) => {
     getUserConfirmation = getConfirmation,
     hashType = 'slash'
   } = props
-  const basename = props.basename ? addLeadingSlash(stripTrailingSlash(props.basename)) : ''
+  const basename = props.basename ? stripTrailingSlash(addLeadingSlash(props.basename)) : ''
 
   const { encodePath, decodePath } = HashPathCoders[hashType]
 


### PR DESCRIPTION
As I mentioned here https://github.com/ReactTraining/history/commit/d91c52b6609c6c30e77f74a195816b16bf4aabac#commitcomment-20916643, I should have tested this before.