### PR TITLE
Fix multiple unlistens

### DIFF
--- a/modules/__tests__/TestSequences/execSteps.js
+++ b/modules/__tests__/TestSequences/execSteps.js
@@ -3,6 +3,8 @@ const execSteps = (steps, history, done) => {
 
   const cleanup = (...args) => {
     unlisten()
+    // Avoid unsubscribing a second time when we double cleanup.
+    unlisten = () => {}
     done(...args)
   }
 


### PR DESCRIPTION
Log a warning instead of decrementing listenerCount again
when the same unlisten function is called multiple times.

Also avoid adding event listeners a second time when
listenerCount is decreased to 1.

Also fix tests to avoid calling unlisten twice.