### PR TITLE
Only encode/decode the pathname

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -15,7 +15,6 @@ export const parsePath = (path) => {
   let search = ''
   let hash = ''
 
-  pathname = decodeURI(pathname)
   const hashIndex = pathname.indexOf('#')
   if (hashIndex !== -1) {
     hash = pathname.substr(hashIndex)
@@ -28,6 +27,8 @@ export const parsePath = (path) => {
     pathname = pathname.substr(0, searchIndex)
   }
 
+  pathname = decodeURI(pathname)
+
   return {
     pathname,
     search: search === '?' ? '' : search,
@@ -38,7 +39,7 @@ export const parsePath = (path) => {
 export const createPath = (location) => {
   const { pathname, search, hash } = location
 
-  let path = pathname || '/'
+  let path = encodeURI(pathname || '/')
 
   if (search && search !== '?')
     path += (search.charAt(0) === '?' ? search : `?${search}`)
@@ -46,5 +47,5 @@ export const createPath = (location) => {
   if (hash && hash !== '#')
     path += (hash.charAt(0) === '#' ? hash : `#${hash}`)
 
-  return encodeURI(path)
+  return path
 }

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -65,7 +65,7 @@ describeHistory('a browser history', () => {
     })
 
     describe('push with an encoded path string', () => {
-      it('creates a location object with decoded properties', (done) => {
+      it('creates a location object with decoded pathname', (done) => {
         TestSequences.PushEncodedLocation(history, done)
       })
     })

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -68,7 +68,7 @@ describeHistory('a hash history', () => {
     })
 
     describe('push with an encoded path string', () => {
-      it('creates a location object with decoded properties', (done) => {
+      it('creates a location object with decoded pathname', (done) => {
         TestSequences.PushEncodedLocation(history, done)
       })
     })

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -57,7 +57,7 @@ describe('a memory history', () => {
     })
 
     describe('push with an encoded path string', () => {
-      it('creates a location object with decoded properties', (done) => {
+      it('creates a location object with decoded pathname', (done) => {
         TestSequences.PushEncodedLocation(history, done)
       })
     })

--- a/modules/__tests__/TestSequences/PushEncodedLocation.js
+++ b/modules/__tests__/TestSequences/PushEncodedLocation.js
@@ -17,8 +17,8 @@ export default (history, done) => {
       expect(action).toBe('PUSH')
       expect(location).toMatch({
         pathname: '/歴史',
-        search: '?キー=値',
-        hash: '#ハッシュ'
+        search: '?%E3%82%AD%E3%83%BC=%E5%80%A4',
+        hash: '#%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5'
       })
     }
   ]

--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -78,17 +78,30 @@ describe('a browser history', () => {
       history = createBrowserHistory({ basename: '/' })
     })
 
-    it('knows how to create hrefs', () => {
+    it('encodes the pathname', () => {
       const href = history.createHref({
-        pathname: '/歴史',
-        search: '?キー=値',
+        pathname: '/歴史'
+      })
+
+      expect(href).toEqual('/%E6%AD%B4%E5%8F%B2')
+    })
+
+    it('does not encode the hash', () => {
+      const href = history.createHref({
+        pathname: '/',
         hash: '#ハッシュ'
       })
 
-      const pathname = '/%E6%AD%B4%E5%8F%B2'
-      const search = '?%E3%82%AD%E3%83%BC=%E5%80%A4'
-      const hash = '#%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5'
-      expect(href).toEqual(pathname + search + hash)
+      expect(href).toEqual('/#ハッシュ')
+    })
+
+    it('does not encode the search string', () => {
+      const href = history.createHref({
+        pathname: '/',
+        search: '?キー=値'
+      })
+
+      expect(href).toEqual('/?キー=値')
     })
   })
 })
@@ -199,15 +212,33 @@ describe('a hash history', () => {
       history = createHashHistory({ basename: '/' })
     })
 
-    it('knows how to create hrefs', () => {
+    it('encodes the pathname', () => {
       const href = history.createHref({
-        pathname: '/歴史',
+        pathname: '/歴史'
+      })
+
+      const pathname = '/%E6%AD%B4%E5%8F%B2'
+      expect(href).toEqual('#' + pathname)
+    })
+
+    it('does not encode the hash', () => {
+      const href = history.createHref({
+        pathname: '/',
+        hash: '#ハッシュ'
+      })
+
+      const hash = '#ハッシュ'
+      expect(href).toEqual('#/' + hash)
+    })
+
+    it('does not encode the search string', () => {
+      const href = history.createHref({
+        pathname: '/',
         search: '?キー=値'
       })
 
-      const pathname = '#/%E6%AD%B4%E5%8F%B2'
-      const search = '?%E3%82%AD%E3%83%BC=%E5%80%A4'
-      expect(href).toEqual(pathname + search)
+      const search = '?キー=値'
+      expect(href).toEqual('#/' + search)
     })
   })
 })
@@ -229,17 +260,35 @@ describe('a memory history', () => {
   })
 
   describe('with a unicode location', () => {
-    it('encodes unicode pathnames', () => {
+    let history
+    beforeEach(() => {
+      history = createMemoryHistory()
+    })
+
+    it('encodes the pathname', () => {
       const href = history.createHref({
-        pathname: '/歴史',
-        search: '?キー=値',
+        pathname: '/歴史'
+      })
+
+      expect(href).toEqual('/%E6%AD%B4%E5%8F%B2')
+    })
+
+    it('does not encode the hash', () => {
+      const href = history.createHref({
+        pathname: '/',
         hash: '#ハッシュ'
       })
 
-      const pathname = '/%E6%AD%B4%E5%8F%B2'
-      const search = '?%E3%82%AD%E3%83%BC=%E5%80%A4'
-      const hash = '#%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5'
-      expect(href).toEqual(pathname + search + hash)
+      expect(href).toEqual('/#ハッシュ')
+    })
+
+    it('does not encode the search string', () => {
+      const href = history.createHref({
+        pathname: '/',
+        search: '?キー=値'
+      })
+
+      expect(href).toEqual('/?キー=値')
     })
   })
 })


### PR DESCRIPTION
The `pathname` is the only part of the URL that React Router cares about, so that is the only part that I am confident in encoding/decoding.

A decoded `search` string that contains a `#` (or any of the other reserved characters) may cause bugs if we only encode it using `encodeURI`.

```js
// starting with the location
{
  pathname: '/',
  search: '?hashtag=#yolo',
  hash: ''
}
// this will create the encoded url /?hashtag=#yolo
// which will be parsed to create the location object
{
  pathname: '/',
  search: '?hashtag=',
  hash: '#yolo'
}
```

If we expect the user to be producing an encoded search string (which the different query modules will automatically do), then we can expect them to produce a valid `search` string.