### PR TITLE
Warn when path does not contain basename

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -59,6 +59,12 @@ const createBrowserHistory = (props = {}) => {
 
     let path = pathname + search + hash
 
+    warning(
+      !(basename && path.indexOf(basename) !== 0),
+      'You are attempting to use a basename on a page whose URL path does not begin ' +
+      'with the basename. Expected path "' + path + '" to begin with "' + basename + '".'
+    )
+
     if (basename)
       path = stripPrefix(path, basename)
 

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -74,6 +74,12 @@ const createHashHistory = (props = {}) => {
   const getDOMLocation = () => {
     let path = decodePath(getHashPath())
 
+    warning(
+      !(basename && path.indexOf(basename) !== 0),
+      'You are attempting to use a basename on a page whose URL path does not begin ' +
+      'with the basename. Expected path "' + path + '" to begin with "' + basename + '".'
+    )
+
     if (basename)
       path = stripPrefix(path, basename)
 


### PR DESCRIPTION
As brought up in #452 

I don't love the tests I wrote, but I added them because I saw that there were test sequences for other warnings. Unfortunately, the only great way to catch the warning was during the creation of a history object, which I couldn't do in a test sequence (because that expects the history to already exist).

I also added some `pushState` calls in the `createHref` tests so that the test output doesn't get littered with warnings.