### PR TITLE
Disable creating `href` for memory history

### DIFF
--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -249,46 +249,13 @@ describe('a memory history', () => {
     history = createMemoryHistory()
   })
 
-  it('knows how to create hrefs', () => {
+  it('does not create hrefs', () => {
     const href = history.createHref({
       pathname: '/the/path',
       search: '?the=query',
       hash: '#the-hash'
     })
 
-    expect(href).toEqual('/the/path?the=query#the-hash')
-  })
-
-  describe('with a unicode location', () => {
-    let history
-    beforeEach(() => {
-      history = createMemoryHistory()
-    })
-
-    it('encodes the pathname', () => {
-      const href = history.createHref({
-        pathname: '/歴史'
-      })
-
-      expect(href).toEqual('/%E6%AD%B4%E5%8F%B2')
-    })
-
-    it('does not encode the hash', () => {
-      const href = history.createHref({
-        pathname: '/',
-        hash: '#ハッシュ'
-      })
-
-      expect(href).toEqual('/#ハッシュ')
-    })
-
-    it('does not encode the search string', () => {
-      const href = history.createHref({
-        pathname: '/',
-        search: '?キー=値'
-      })
-
-      expect(href).toEqual('/?キー=値')
-    })
+    expect(href).toEqual(null)
   })
 })

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -42,7 +42,7 @@ const createMemoryHistory = (props = {}) => {
 
   // Public interface
 
-  const createHref = createPath
+  const createHref = () => null;
 
   const push = (path, state) => {
     warning(


### PR DESCRIPTION
When using memory history, the href that created by history is unnecessary for users.
If users knows the URL from href, they will visit and meet route not found :<
The routing structure should be hidden in internal.