### PR TITLE
avoid adding leading slash to already full qualified urls to origin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The options that each `create` method takes, along with its default values, are:
 ```js
 createBrowserHistory({
   basename: '',             // The base URL of the app (see below)
+  includeOrigin: false,     // Set true to include the origin in generated urls. 
   forceRefresh: false,      // Set true to force full page refreshes
   keyLength: 6,             // The length of location.key
   // A function to use to confirm navigation with the user (see below)

--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -36,6 +36,14 @@ export const supportsHistory = () => {
 }
 
 /**
+ * Polyfill returns window.location.origin 
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/location#Browser_compatibility
+ */
+export const getOrigin = () =>
+  window.location.origin ||
+  window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+
+/**
  * Returns true if browser fires popstate on hash change.
  * IE10 and IE11 do not.
  */

--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -1,4 +1,5 @@
 import expect from 'expect'
+import { getOrigin } from '../DOMUtils'
 import createBrowserHistory from '../createBrowserHistory'
 import createHashHistory from '../createHashHistory'
 import createMemoryHistory from '../createMemoryHistory'
@@ -69,6 +70,34 @@ describe('a browser history', () => {
       })
 
       expect(href).toEqual('/the/path?the=query#the-hash')
+    })
+  })
+
+  describe('with includeOrigin', () => {
+    let history
+
+    it('knows how to create hrefs', () => {
+      history = createBrowserHistory({ includeOrigin: true })
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      })
+
+      const origin = getOrigin();
+      expect(href).toEqual(`${origin}/the/path?the=query#the-hash`)
+    })
+
+    it('and basename, knows how to create hrefs', () => {
+      history = createBrowserHistory({ includeOrigin: true, basename: '/the/base' })
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      })
+
+      const origin = getOrigin();
+      expect(href).toEqual(`${origin}/the/base/the/path?the=query#the-hash`)
     })
   })
 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -51,7 +51,9 @@ const createBrowserHistory = (props = {}) => {
     getUserConfirmation = getConfirmation,
     keyLength = 6
   } = props
-  const basename = props.basename ? stripTrailingSlash(addLeadingSlash(props.basename)) : ''
+  const rawBasename = props.basename || '';
+  const isFullUrl = rawBasename.indexOf(window.location.origin) === 0;
+  const basename = stripTrailingSlash(isFullUrl ? rawBasename : addLeadingSlash(rawBasename));
 
   const getDOMLocation = (historyState) => {
     const { key, state } = (historyState || {})

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -15,6 +15,7 @@ import {
   removeEventListener,
   getConfirmation,
   supportsHistory,
+  getOrigin,
   supportsPopStateOnHashChange,
   isExtraneousPopstateEvent
 } from './DOMUtils'
@@ -51,9 +52,7 @@ const createBrowserHistory = (props = {}) => {
     getUserConfirmation = getConfirmation,
     keyLength = 6
   } = props
-  const rawBasename = props.basename || '';
-  const isFullUrl = rawBasename.indexOf(window.location.origin) === 0;
-  const basename = stripTrailingSlash(isFullUrl ? rawBasename : addLeadingSlash(rawBasename));
+  const basename = props.basename ? stripTrailingSlash(addLeadingSlash(props.basename)) : ''
 
   const getDOMLocation = (historyState) => {
     const { key, state } = (historyState || {})
@@ -90,7 +89,7 @@ const createBrowserHistory = (props = {}) => {
   const handlePopState = (event) => {
     // Ignore extraneous popstate events in WebKit.
     if (isExtraneousPopstateEvent(event))
-      return 
+      return
 
     handlePop(getDOMLocation(event.state))
   }
@@ -144,12 +143,14 @@ const createBrowserHistory = (props = {}) => {
   }
 
   const initialLocation = getDOMLocation(getHistoryState())
-  let allKeys = [ initialLocation.key ]
+  let allKeys = [initialLocation.key]
 
   // Public interface
 
-  const createHref = (location) =>
-    basename + createPath(location)
+  const createHref = (location) => {
+    var origin = props.includeOrigin ? getOrigin() : '';
+    return origin + basename + createPath(location);
+  }
 
   const push = (path, state) => {
     warning(


### PR DESCRIPTION
This change avoids adding unnecessary leading slashes when basename is set to window.location.origin.

There was some discussion about why this is useful here: https://github.com/ReactTraining/react-router/issues/4885#issuecomment-290818502

** And here is an example that further ilustrates why this is useful:**
http://jsbin.com/deyovujamu/edit?html,js,output

Things to note in the example:
- all image links are relative
- we specify the cdn host name using `<base href="https://c1.staticflickr.com">`
- Images are loading correctly !!!
- links are broken. instead of referring to `http://null.jsbin.com/about`, it will point to `https://c1.staticflickr.com/http://null.jsbin.com/about` that's because history always add leading slash, and then the browser adds the base href.

