### PR TITLE
Per-block custom user confirm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## HEAD
+> Jun 04, 2017
+
+- Added per-block user confirm customization
+
 ## [v4.6.1]
 > Mar 15, 2017
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ const history = createHistory({
 })
 ```
 
+If a block requires a unique dialog or special functionality, you may curry a custom confirm function in the `history.block()` function.
+
+```js
+history.block((location, action) => (callback) => {
+  // Call callback() as used in getUserConfirmation()
+  // Note: getUserConfirmation is replaced by this function for this block.
+})
+```
+
 ### Using a Base URL
 
 If all the URLs in your app are relative to some other "base" URL, use the `basename` option. This option transparently adds the given string to the front of all URLs you use.

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -170,6 +170,21 @@ describeHistory('a browser history', () => {
     })
   })
 
+  describe('with a custom confirm', () => {
+    const getUserConfirmation = (_, callback) => callback(true)
+
+    let history
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      })
+    })
+
+    it('replaces the user confirmation from history creation', (done) => {
+      TestSequences.BlockWithCustomConfirm(history, done)
+    })
+  })
+
   describe('basename', () => {
     it('strips the basename from the pathname', () => {
       window.history.replaceState(null, null, '/prefix/pathname')

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -171,6 +171,21 @@ describeHistory('a hash history', () => {
     })
   })
 
+  describe('with a custom confirm', () => {
+    const getUserConfirmation = (_, callback) => callback(true)
+
+    let history
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      })
+    })
+
+    it('replaces the user confirmation from history creation', (done) => {
+      TestSequences.BlockWithCustomConfirm(history, done)
+    })
+  })
+
   describe('"hashbang" hash path coding', () => {
     let history
     beforeEach(() => {

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -152,4 +152,19 @@ describe('a memory history', () => {
       TestSequences.ReturnFalseTransitionHook(history, done)
     })
   })
+
+  describe('with a custom confirm', () => {
+    const getUserConfirmation = (_, callback) => callback(true)
+
+    let history
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      })
+    })
+
+    it('replaces the user confirmation from history creation', (done) => {
+      TestSequences.BlockWithCustomConfirm(history, done)
+    })
+  })
 })

--- a/modules/__tests__/TestSequences/BlockWithCustomConfirm.js
+++ b/modules/__tests__/TestSequences/BlockWithCustomConfirm.js
@@ -1,0 +1,29 @@
+import expect from 'expect'
+import execSteps from './execSteps'
+
+export default (history, done) => {
+  const steps = [
+    (location) => {
+      expect(location).toMatch({
+        pathname: '/'
+      })
+
+      let wasCurried = false
+      const unblock = history.block(() => (callback) => {
+        wasCurried = true
+        callback(false)
+      })
+
+      history.push('/home')
+
+      expect(wasCurried).toBe(true)
+      expect(history.location).toMatch({
+        pathname: '/'
+      })
+
+      unblock()
+    }
+  ]
+
+  execSteps(steps, history, done)
+}

--- a/modules/__tests__/TestSequences/index.js
+++ b/modules/__tests__/TestSequences/index.js
@@ -1,6 +1,7 @@
 export BackButtonTransitionHook from './BackButtonTransitionHook'
 export BlockEverything from './BlockEverything'
 export BlockPopWithoutListening from './BlockPopWithoutListening'
+export BlockWithCustomConfirm from './BlockWithCustomConfirm'
 export DenyPush from './DenyPush'
 export DenyGoBack from './DenyGoBack'
 export DenyGoForward from './DenyGoForward'

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -24,7 +24,9 @@ const createTransitionManager = () => {
     if (prompt != null) {
       const result = typeof prompt === 'function' ? prompt(location, action) : prompt
 
-      if (typeof result === 'string') {
+      if (typeof result === 'function') {
+        result(callback)
+      } else if (typeof result === 'string') {
         if (typeof getUserConfirmation === 'function') {
           getUserConfirmation(result, callback)
         } else {


### PR DESCRIPTION
I found the need to have more information available at user-confirm time than a string could provide, and also the need to customize further than only a different message. This change adds the capability to curry a custom user-confirm function when creating the block, which makes the task easy.