### PR TITLE
Fix logic bug when displaying history basename warning messages

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -60,7 +60,7 @@ const createBrowserHistory = (props = {}) => {
     let path = pathname + search + hash
 
     warning(
-      !(basename && hasBasename(path, basename)),
+      (!basename || hasBasename(path, basename)),
       'You are attempting to use a basename on a page whose URL path does not begin ' +
       'with the basename. Expected path "' + path + '" to begin with "' + basename + '".'
     )

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -75,7 +75,7 @@ const createHashHistory = (props = {}) => {
     let path = decodePath(getHashPath())
 
     warning(
-      !(basename && hasBasename(path, basename)),
+      (!basename || hasBasename(path, basename)),
       'You are attempting to use a basename on a page whose URL path does not begin ' +
       'with the basename. Expected path "' + path + '" to begin with "' + basename + '".'
     )


### PR DESCRIPTION
Previously, if "there is a basename" but the path "has the basename" the warning would show.

Now correctly doesn't show the warning.