### PR TITLE
Add path-to-regexp style basename

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 
+> Jun 6, 2017
+
+- Add path-to-regexp to the `basename` parsing, allowing use of parameters in `basename`
+
 ## [v4.6.1]
 > Mar 15, 2017
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ history.listen(location => {
 history.push('/home') // URL is now /the/base/home
 ```
 
+You can use parameters in the basename, using [path-to-regexp](https://github.com/pillarjs/path-to-regexp)
+
+```js
+const history = createHistory({
+  basename: '/the/:param/base'
+})
+```
+
 **Note:** `basename` is not suppported in `createMemoryHistory`.
 
 ### Forcing Full Page Refreshes in createBrowserHistory

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -206,5 +206,25 @@ describeHistory('a browser history', () => {
       const history = createHistory({ basename: '/prefix' })
       expect(history.location.pathname).toEqual('/')
     })
+
+    describe('path params', () => {
+      it('strips the basename', () => {
+        window.history.replaceState(null, null, '/PREFIX/PARAM/pathname')
+        const history = createHistory({ basename: '/prefix/:param/pathname' })
+        expect(history.location.pathname).toEqual('/')
+      })
+
+      it('strips when path is only the prefix', () => {
+        window.history.replaceState(null, null, '/PREFIX/PARAM/pathname')
+        const history = createHistory({ basename: '/prefix/:param' })
+        expect(history.location.pathname).toEqual('/pathname')
+      })
+
+      it('strips when path is only the prefix with multiple params', () => {
+        window.history.replaceState(null, null, '/PREFIX/PARAM/midfix/PARAM/pathname')
+        const history = createHistory({ basename: '/prefix/:param/midfix/:param' })
+        expect(history.location.pathname).toEqual('/pathname')
+      })
+    })
   })
 })

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -247,5 +247,25 @@ describeHistory('a hash history', () => {
       const history = createHistory({ basename: '/prefix' })
       expect(history.location.pathname).toEqual('/')
     })
+
+    describe('path params', () => {
+      it('strips the basename', () => {
+        window.history.replaceState(null, null, '#/PREFIX/PARAM/pathname')
+        const history = createHistory({ basename: '/prefix/:param/pathname' })
+        expect(history.location.pathname).toEqual('/')
+      })
+
+      it('strips when path is only the prefix', () => {
+        window.history.replaceState(null, null, '#/PREFIX/PARAM/pathname')
+        const history = createHistory({ basename: '/prefix/:param' })
+        expect(history.location.pathname).toEqual('/pathname')
+      })
+
+      it('strips when path is only the prefix with multiple params', () => {
+        window.history.replaceState(null, null, '#/PREFIX/PARAM/midfix/PARAM/pathname')
+        const history = createHistory({ basename: '/prefix/:param/midfix/:param' })
+        expect(history.location.pathname).toEqual('/pathname')
+      })
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "invariant": "^2.2.1",
     "loose-envify": "^1.2.0",
+    "path-to-regexp": "^1.5.3",
     "resolve-pathname": "^2.0.0",
     "value-equal": "^0.2.0",
     "warning": "^3.0.0"


### PR DESCRIPTION
Allow path parameters in the `basename` (e.g. `basename` of '/never/:param' will remove '/never/gonna' from path '/never/gonna/give').

Using same package ('path-to-regexp') as react-router for its matchPath (so the behavior should be the same as the `path` prop of `<Route />`).

Tests, README.md, and CHANGES.md updated.