### PR TITLE
Make hash history warning into console.warn

### DIFF
--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -214,10 +214,7 @@ const createHashHistory = (props = {}) => {
 
         setState({ action, location })
       } else {
-        warning(
-          false,
-          'Hash history cannot PUSH the same path; a new entry will not be added to the history stack'
-        )
+        console.warn('Hash history cannot PUSH the same path; a new entry will not be added to the history stack');
 
         setState()
       }


### PR DESCRIPTION
This PR is for making the notorious 'Hash history cannot PUSH the same path; a new entry will not be added to the history stack' into a console.warn rather than a console.error. When using React Router, this warning will spam the console cause confusion and concern. Changing the warning to a console.warn will better serve it's purpose. 

Current:
![hashpoppingslasher](https://user-images.githubusercontent.com/10493910/26906575-ca7d9878-4bb3-11e7-87ca-be2879e4a78b.png)

Desired:
![hashquietpopper](https://user-images.githubusercontent.com/10493910/26906580-cf0653ee-4bb3-11e7-9ca6-b545f03051c0.png)

