### PR TITLE
Implements new API for blocking transitions with generic pre-location-change hook

### DIFF
--- a/modules/.babelrc
+++ b/modules/.babelrc
@@ -7,6 +7,11 @@
     "transform-object-assign"
   ],
   "env": {
+    "test": {
+      "plugins": [
+        "transform-runtime"
+      ]
+    },
     "production": {
       "plugins": [
         "dev-expression"

--- a/modules/.eslintrc
+++ b/modules/.eslintrc
@@ -4,7 +4,8 @@
     "import"
   ],
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "extends": [
     "eslint:recommended",

--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -12,9 +12,6 @@ export const removeEventListener = (node, event, listener) =>
     ? node.removeEventListener(event, listener, false)
     : node.detachEvent('on' + event, listener)
 
-export const getConfirmation = (message, callback) =>
-  callback(window.confirm(message)) // eslint-disable-line no-alert
-
 /**
  * Returns true if the HTML5 history API is supported. Taken from Modernizr.
  *

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -125,20 +125,20 @@ describeHistory('a browser history', () => {
       })
     })
 
-    describe('block', () => {
+    describe.skip('block', () => {
       it('blocks all transitions', (done) => {
         TestSequences.BlockEverything(history, done)
       })
     })
 
-    describe('block a POP without listening', () => {
+    describe.skip('block a POP without listening', () => {
       it('receives the next location and action as arguments', (done) => {
         TestSequences.BlockPopWithoutListening(history, done)
       })
     })
   })
 
-  describe('that denies all transitions', () => {
+  describe.skip('that denies all transitions', () => {
     const getUserConfirmation = (_, callback) => callback(false)
 
     let history
@@ -167,7 +167,7 @@ describeHistory('a browser history', () => {
     })
   })
 
-  describe('a transition hook', () => {
+  describe.skip('a transition hook', () => {
     const getUserConfirmation = (_, callback) => callback(true)
 
     let history

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -128,20 +128,20 @@ describeHistory('a hash history', () => {
       })
     })
 
-    describe('block', () => {
+    describe.skip('block', () => {
       it('blocks all transitions', (done) => {
         TestSequences.BlockEverything(history, done)
       })
     })
 
-    describeGo('block a POP without listening', () => {
+    describeGo.skip('block a POP without listening', () => {
       it('receives the next location and action as arguments', (done) => {
         TestSequences.BlockPopWithoutListening(history, done)
       })
     })
   })
 
-  describe('that denies all transitions', () => {
+  describe.skip('that denies all transitions', () => {
     const getUserConfirmation = (_, callback) => callback(false)
 
     let history
@@ -170,7 +170,7 @@ describeHistory('a hash history', () => {
     })
   })
 
-  describe('a transition hook', () => {
+  describe.skip('a transition hook', () => {
     const getUserConfirmation = (_, callback) => callback(true)
 
     let history

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -116,20 +116,20 @@ describe('a memory history', () => {
       })
     })
 
-    describe('block', () => {
+    describe.skip('block', () => {
       it('blocks all transitions', (done) => {
         TestSequences.BlockEverything(history, done)
       })
     })
 
-    describe('block a POP without listening', () => {
+    describe.skip('block a POP without listening', () => {
       it('receives the next location and action as arguments', (done) => {
         TestSequences.BlockPopWithoutListening(history, done)
       })
     })
   })
 
-  describe('that denies all transitions', () => {
+  describe.skip('that denies all transitions', () => {
     const getUserConfirmation = (_, callback) => callback(false)
 
     let history
@@ -158,7 +158,7 @@ describe('a memory history', () => {
     })
   })
 
-  describe('a transition hook', () => {
+  describe.skip('a transition hook', () => {
     const getUserConfirmation = (_, callback) => callback(true)
 
     let history

--- a/modules/__tests__/TransitionManager-test.js
+++ b/modules/__tests__/TransitionManager-test.js
@@ -8,7 +8,7 @@ describe('transition manager', () => {
     manager = createTransitionManager()
   })
 
-  it('should notify all of its listeners functions registered with "after" when "transition" is called', () => {
+  it('notifies all of its listeners functions registered with "after" when "transition" is called', () => {
     const fn1 = createSpy()
     const fn2 = createSpy()
     const arg1 = 'foo'
@@ -18,7 +18,7 @@ describe('transition manager', () => {
     ;[fn1, fn2].forEach(fn => expect(fn).toHaveBeenCalledWith(arg1, arg2))
   })
 
-  it('should iterate through the pre-transition listeners registered with "before" when "confirmTransitionTo" is called', async () => {
+  it('iterates through the pre-transition listeners registered with "before" when "confirmTransitionTo" is called', async () => {
     const fn1 = createSpy()
     const fn2 = createSpy()
     const arg1 = 'foo'
@@ -29,7 +29,7 @@ describe('transition manager', () => {
     ;[fn1, fn2].forEach(fn => expect(fn).toHaveBeenCalledWith(arg1, arg2))
   })
 
-  it('should return false from the async "confirmTransitionTo" function if any of the async pre-listeners return a truthy value', async () => {
+  it('returns false from the async "confirmTransitionTo" function if any of the async pre-listeners return a truthy value', async () => {
     const fn1 = createSpy()
     let fn2 = createSpy(async () => {
       await delay(2)
@@ -44,7 +44,7 @@ describe('transition manager', () => {
     expect(fn3).toNotHaveBeenCalled()
   })
 
-  it('should return an idempotent unsubscribe function when registering before listeners', async () => {
+  it('returns an idempotent unsubscribe function when registering before listeners', async () => {
     const fn1 = createSpy()
     const unsub = manager.before(fn1)
     await manager.confirmTransitionTo()
@@ -54,7 +54,7 @@ describe('transition manager', () => {
     expect(fn1.calls.length).toBe(1)
   })
 
-  it('should return an idempotent unsubscribe function when registering after listeners', () => {
+  it('returns an idempotent unsubscribe function when registering after listeners', () => {
     const fn1 = createSpy()
     const unsub = manager.appendListener(fn1)
     manager.notifyListeners()
@@ -64,7 +64,7 @@ describe('transition manager', () => {
     expect(fn1.calls.length).toBe(1)
   })
 
-  it('will can unsubscribe multiple pre-hooks in one call if a function has been registered more than once', () => {
+  it('unsubscribes multiple pre-hooks in one call if a function has been registered more than once', () => {
     const beforeHook = createSpy()
     const unsubBefore = manager.before(beforeHook)
     manager.before(beforeHook)
@@ -73,7 +73,7 @@ describe('transition manager', () => {
     expect(beforeHook).toNotHaveBeenCalled()
   })
 
-  it('will have unique unsubscribe functions for appendListener', () => {
+  it('has unique unsubscribe functions for appendListener', () => {
     const afterHook = createSpy()
     const unsubAfter = manager.appendListener(afterHook)
     manager.appendListener(afterHook)

--- a/modules/__tests__/TransitionManager-test.js
+++ b/modules/__tests__/TransitionManager-test.js
@@ -1,0 +1,85 @@
+import expect, { createSpy } from 'expect'
+import delay from './delay'
+import createTransitionManager from '../createTransitionManager'
+
+describe('transition manager', () => {
+  let manager
+  beforeEach(() => {
+    manager = createTransitionManager()
+  })
+
+  it('should notify all of its listeners functions registered with "after" when "transition" is called', () => {
+    const fn1 = createSpy()
+    const fn2 = createSpy()
+    const arg1 = 'foo'
+    const arg2 = 'bar'
+    ;[fn1, fn2].forEach(fn => manager.appendListener(fn))
+    manager.notifyListeners(arg1, arg2)
+    ;[fn1, fn2].forEach(fn => expect(fn).toHaveBeenCalledWith(arg1, arg2))
+  })
+
+  it('should iterate through the pre-transition listeners registered with "before" when "confirmTransitionTo" is called', async () => {
+    const fn1 = createSpy()
+    const fn2 = createSpy()
+    const arg1 = 'foo'
+    const arg2 = 'bar'
+    ;[fn1, fn2].forEach(fn => manager.before(fn))
+    const res = await manager.confirmTransitionTo(arg1, arg2)
+    expect(res).toBe(true)
+    ;[fn1, fn2].forEach(fn => expect(fn).toHaveBeenCalledWith(arg1, arg2))
+  })
+
+  it('should return false from the async "confirmTransitionTo" function if any of the async pre-listeners return a truthy value', async () => {
+    const fn1 = createSpy()
+    let fn2 = createSpy(async () => {
+      await delay(2)
+      return true
+    }).andCallThrough()
+    const fn3 = createSpy();
+    [fn1, fn2, fn3].forEach(fn => manager.before(fn))
+    const res = await manager.confirmTransitionTo()
+    expect(res).toBe(false)
+    expect(fn1).toHaveBeenCalled()
+    expect(fn2).toHaveBeenCalled()
+    expect(fn3).toNotHaveBeenCalled()
+  })
+
+  it('should return an idempotent unsubscribe function when registering before listeners', async () => {
+    const fn1 = createSpy()
+    const unsub = manager.before(fn1)
+    await manager.confirmTransitionTo()
+    expect(fn1).toHaveBeenCalled()
+    unsub(); unsub(); unsub()
+    await manager.confirmTransitionTo()
+    expect(fn1.calls.length).toBe(1)
+  })
+
+  it('should return an idempotent unsubscribe function when registering after listeners', () => {
+    const fn1 = createSpy()
+    const unsub = manager.appendListener(fn1)
+    manager.notifyListeners()
+    expect(fn1).toHaveBeenCalled()
+    unsub(); unsub(); unsub()
+    manager.notifyListeners()
+    expect(fn1.calls.length).toBe(1)
+  })
+
+  it('will can unsubscribe multiple pre-hooks in one call if a function has been registered more than once', () => {
+    const beforeHook = createSpy()
+    const unsubBefore = manager.before(beforeHook)
+    manager.before(beforeHook)
+    unsubBefore()
+    manager.notifyListeners()
+    expect(beforeHook).toNotHaveBeenCalled()
+  })
+
+  it('will have unique unsubscribe functions for appendListener', () => {
+    const afterHook = createSpy()
+    const unsubAfter = manager.appendListener(afterHook)
+    manager.appendListener(afterHook)
+    manager.appendListener(afterHook)
+    unsubAfter()
+    manager.notifyListeners()
+    expect(afterHook).toHaveBeenCalled()
+  })
+})

--- a/modules/__tests__/delay.js
+++ b/modules/__tests__/delay.js
@@ -1,0 +1,3 @@
+export default function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -132,7 +132,7 @@ const createHashHistory = (props = {}) => {
     } else {
       const action = 'POP'
 
-      transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
+      transitionManager.confirmTransitionTo(location, action).then(ok => {
         if (ok) {
           setState({ action, location })
         } else {
@@ -191,7 +191,7 @@ const createHashHistory = (props = {}) => {
     const action = 'PUSH'
     const location = createLocation(path, undefined, undefined, history.location)
 
-    transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
+    transitionManager.confirmTransitionTo(location, action).then(ok => {
       if (!ok)
         return
 
@@ -233,7 +233,7 @@ const createHashHistory = (props = {}) => {
     const action = 'REPLACE'
     const location = createLocation(path, undefined, undefined, history.location)
 
-    transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
+    transitionManager.confirmTransitionTo(location, action).then(ok => {
       if (!ok)
         return
 
@@ -285,23 +285,13 @@ const createHashHistory = (props = {}) => {
     }
   }
 
-  let isBlocked = false
-
-  const block = (prompt = false) => {
-    const unblock = transitionManager.setPrompt(prompt)
-
-    if (!isBlocked) {
-      checkDOMListeners(1)
-      isBlocked = true
-    }
+  const before = (hook) => {
+    const unhook = transitionManager.before(hook)
+    checkDOMListeners(1)
 
     return () => {
-      if (isBlocked) {
-        isBlocked = false
-        checkDOMListeners(-1)
-      }
-
-      return unblock()
+      unhook()
+      checkDOMListeners(-1)
     }
   }
 
@@ -325,7 +315,7 @@ const createHashHistory = (props = {}) => {
     go,
     goBack,
     goForward,
-    block,
+    before,
     listen
   }
 

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -14,7 +14,6 @@ import {
   canUseDOM,
   addEventListener,
   removeEventListener,
-  getConfirmation,
   supportsGoWithoutReloadUsingHash
 } from './DOMUtils'
 
@@ -64,7 +63,6 @@ const createHashHistory = (props = {}) => {
   const canGoWithoutReload = supportsGoWithoutReloadUsingHash()
 
   const {
-    getUserConfirmation = getConfirmation,
     hashType = 'slash'
   } = props
   const basename = props.basename ? stripTrailingSlash(addLeadingSlash(props.basename)) : ''

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -11,7 +11,6 @@ const clamp = (n, lowerBound, upperBound) =>
  */
 const createMemoryHistory = (props = {}) => {
   const {
-    getUserConfirmation,
     initialEntries = [ '/' ],
     initialIndex = 0,
     keyLength = 6
@@ -54,7 +53,7 @@ const createMemoryHistory = (props = {}) => {
     const action = 'PUSH'
     const location = createLocation(path, state, createKey(), history.location)
 
-    transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
+    transitionManager.confirmTransitionTo(location, action).then(ok => {
       if (!ok)
         return
 
@@ -87,7 +86,7 @@ const createMemoryHistory = (props = {}) => {
     const action = 'REPLACE'
     const location = createLocation(path, state, createKey(), history.location)
 
-    transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
+    transitionManager.confirmTransitionTo(location, action).then(ok => {
       if (!ok)
         return
 
@@ -103,7 +102,7 @@ const createMemoryHistory = (props = {}) => {
     const action = 'POP'
     const location = history.entries[nextIndex]
 
-    transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
+    transitionManager.confirmTransitionTo(location, action).then(ok => {
       if (ok) {
         setState({
           action,
@@ -129,8 +128,8 @@ const createMemoryHistory = (props = {}) => {
     return nextIndex >= 0 && nextIndex < history.entries.length
   }
 
-  const block = (prompt = false) =>
-    transitionManager.setPrompt(prompt)
+  const before = (hook) =>
+    transitionManager.before(hook)
 
   const listen = (listener) =>
     transitionManager.appendListener(listener)
@@ -148,7 +147,7 @@ const createMemoryHistory = (props = {}) => {
     goBack,
     goForward,
     canGo,
-    block,
+    before,
     listen
   }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clean": "git clean -fdX .",
     "release": "node ./tools/release.js",
     "lint": "eslint modules",
-    "test": "karma start --single-run"
+    "test": "NODE_ENV=test karma start --single-run"
   },
   "dependencies": {
     "invariant": "^2.2.1",
@@ -41,8 +41,10 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
+    "babel-runtime": "^6.23.0",
     "eslint": "^3.3.0",
     "eslint-plugin-import": "^2.0.0",
     "expect": "^1.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,12 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "0.9.8"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz#e008df01340fdc87e959da65991b7e05970c8c7c"
@@ -770,7 +776,7 @@ babel-register@^6.23.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:


### PR DESCRIPTION
A new `before` method allows functions to register as pre-transition hooks that get called before a change in history's state. These methods can be async by returning a promise.

This new pre-hook functionality simplifies the API for conditional or asynchronous blocking of a location transition. It removes the responsibility of determining how to ask a user for their confirmation from the library and leaves it up to the application.

History instances no longer have a `block` method and the factory functions no longer receive a `getUserConfirmation` option.

The API allows for multiple pre-hooks to be registered, so I think it can also resolve the dispute over including query parsing & stringifying, since that feature can simply be added as a pre-transition hook.

~~I also organized and simplified the tests, and added expanded coverage on expectations about the window's state vs the history's state when blocking transitions asynchronously. I changed the async primitive of TestSequence files and `execSteps` to be a promise instead of a callback. This allows for async functions to be used, which is much simpler to follow and catch errors for. Additionally, I reworked the TestSequence files to include their `describe` and `it` blocks
to cut down on the repeated test descriptions.~~

~~One significant tradeoff to the hook implementation is that it now requires the library to have `babel-runtime` as a peer dependency in order to run the transpiled version of the `async` function and be sure of the global `Promise` availability. The implementation is certainly the most succinct way to iterate through an array asynchronously with bailout functionality, but I acknowledge babel-runtime is not the lightest dependency. I'm happy to discuss other options.~~

~~I also made the unlisten functions idempotent. I didn't realize #440 was already
open for this same behavior. This implementation uses one less variable,
but mutates an argument, which can be a questionable pattern but I think
is fine here~~

I think this covers #483, #484, & #489