### PR TITLE
Add main/module entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "repository": "ReactTraining/history",
   "license": "MIT",
   "author": "Michael Jackson",
+  "main": "index.js",
+  "module": "es/index.js",
   "files": [
     "DOMUtils.js",
     "ExecutionEnvironment.js",


### PR DESCRIPTION
I didn't realize that these fields were missing until I came across an issue with using history on CodeSandbox https://github.com/CompuIves/codesandbox-client/issues/22.