### PR TITLE
Add rawPathname to location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- Add `rawPathname` property to location objects and prefer that over `pathname` in `createPath`. For browser and hash histories, `rawPathname` is an encoded string, while for memory histories, it is the same as the `pathname`.
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -56,3 +56,9 @@ export const supportsGoWithoutReloadUsingHash = () =>
 export const isExtraneousPopstateEvent = event =>
   event.state === undefined &&
   navigator.userAgent.indexOf('CriOS') === -1
+
+export const browserEncode = pathname => {
+  const a = document.createElement('a')
+  a.href = pathname
+  return a.pathname
+}

--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -2,7 +2,9 @@ import resolvePathname from 'resolve-pathname'
 import valueEqual from 'value-equal'
 import { parsePath } from './PathUtils'
 
-export const createLocation = (path, state, key, currentLocation) => {
+const defaultRaw = p => p
+
+export const createLocation = (path, state, key, currentLocation, raw = defaultRaw) => {
   let location
   if (typeof path === 'string') {
     // Two-arg form: push(path, state)
@@ -32,6 +34,8 @@ export const createLocation = (path, state, key, currentLocation) => {
     if (state !== undefined && location.state === undefined)
       location.state = state
   }
+
+  location.rawPathname = raw(location.pathname);
 
   try {
     location.pathname = decodeURI(location.pathname)

--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -38,9 +38,9 @@ export const parsePath = (path) => {
 }
 
 export const createPath = (location) => {
-  const { pathname, search, hash } = location
+  const { rawPathname, pathname, search, hash } = location
 
-  let path = pathname || '/'
+  let path = rawPathname || pathname || '/'
 
   if (search && search !== '?')
     path += (search.charAt(0) === '?' ? search : `?${search}`)

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -66,7 +66,7 @@ describeHistory('a browser history', () => {
     })
 
     describe('push with an encoded path string', () => {
-      it('creates a location object with decoded pathname', (done) => {
+      it('creates a location object with decoded pathname and rawPathname', (done) => {
         TestSequences.PushEncodedLocation(history, done)
       })
     })

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -69,7 +69,7 @@ describeHistory('a hash history', () => {
     })
 
     describe('push with an encoded path string', () => {
-      it('creates a location object with decoded pathname', (done) => {
+      it('creates a location object with decoded pathname and rawPathname', (done) => {
         TestSequences.PushEncodedLocation(history, done)
       })
     })

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -57,7 +57,7 @@ describe('a memory history', () => {
     })
 
     describe('push with an encoded path string', () => {
-      it('creates a location object with decoded pathname', (done) => {
+      it('creates a location object with decoded pathname and rawPathname', (done) => {
         TestSequences.PushEncodedLocation(history, done)
       })
     })

--- a/modules/__tests__/TestSequences/PushEncodedLocation.js
+++ b/modules/__tests__/TestSequences/PushEncodedLocation.js
@@ -17,6 +17,7 @@ export default (history, done) => {
       expect(action).toBe('PUSH')
       expect(location).toMatch({
         pathname: '/歴史',
+        rawPathname: '/%E6%AD%B4%E5%8F%B2',
         search: '?%E3%82%AD%E3%83%BC=%E5%80%A4',
         hash: '#%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5'
       })

--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -78,18 +78,13 @@ describe('a browser history', () => {
       history = createBrowserHistory()
     })
 
-    it('does not encode the generated path', () => {
-      // encoded
-      const encodedHref = history.createHref({
-        pathname: '/%23abc'
-      })
-      // unencoded
-      const unencodedHref = history.createHref({
-        pathname: '/#abc'
-      })
-
-      expect(encodedHref).toEqual('/%23abc')
-      expect(unencodedHref).toEqual('/#abc')
+    it('prefers the rawPathname over the pathname', () => {
+      const location = {
+        rawPathname: '/test%20ing',
+        pathname: '/test ing'
+      }
+      const href = history.createHref(location)
+      expect(href).toEqual('/test%20ing')
     })
   })
 })
@@ -200,18 +195,13 @@ describe('a hash history', () => {
       history = createHashHistory()
     })
 
-    it('does not encode the generated path', () => {
-      // encoded
-      const encodedHref = history.createHref({
-        pathname: '/%23abc'
-      })
-      // unencoded
-      const unencodedHref = history.createHref({
-        pathname: '/#abc'
-      })
-
-      expect(encodedHref).toEqual('#/%23abc')
-      expect(unencodedHref).toEqual('#/#abc')
+    it('prefers the rawPathname over the pathname', () => {
+      const location = {
+        rawPathname: '/test%20ing',
+        pathname: '/test ing'
+      }
+      const href = history.createHref(location)
+      expect(href).toEqual('#/test%20ing')
     })
   })
 })
@@ -238,18 +228,14 @@ describe('a memory history', () => {
       history = createMemoryHistory()
     })
 
-    it('does not encode the generated path', () => {
-      // encoded
-      const encodedHref = history.createHref({
-        pathname: '/%23abc'
-      })
-      // unencoded
-      const unencodedHref = history.createHref({
-        pathname: '/#abc'
-      })
-
-      expect(encodedHref).toEqual('/%23abc')
-      expect(unencodedHref).toEqual('/#abc')
+    it('prefers the rawPathname over the pathname', () => {
+      // memory history's rawPathname is same as pathname
+      const location = {
+        rawPathname: '/test ing',
+        pathname: '/test ing'
+      }
+      const href = history.createHref(location)
+      expect(href).toEqual('/test ing')
     })
   })
 })

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -16,7 +16,8 @@ import {
   getConfirmation,
   supportsHistory,
   supportsPopStateOnHashChange,
-  isExtraneousPopstateEvent
+  isExtraneousPopstateEvent,
+  browserEncode
 } from './DOMUtils'
 
 const PopStateEvent = 'popstate'
@@ -68,7 +69,7 @@ const createBrowserHistory = (props = {}) => {
     if (basename)
       path = stripBasename(path, basename)
 
-    return createLocation(path, state, key)
+    return createLocation(path, state, key, undefined, browserEncode)
   }
 
   const createKey = () =>
@@ -159,7 +160,7 @@ const createBrowserHistory = (props = {}) => {
     )
 
     const action = 'PUSH'
-    const location = createLocation(path, state, createKey(), history.location)
+    const location = createLocation(path, state, createKey(), history.location, browserEncode)
 
     transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
       if (!ok)
@@ -201,7 +202,7 @@ const createBrowserHistory = (props = {}) => {
     )
 
     const action = 'REPLACE'
-    const location = createLocation(path, state, createKey(), history.location)
+    const location = createLocation(path, state, createKey(), history.location, browserEncode)
 
     transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
       if (!ok)

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -15,7 +15,8 @@ import {
   addEventListener,
   removeEventListener,
   getConfirmation,
-  supportsGoWithoutReloadUsingHash
+  supportsGoWithoutReloadUsingHash,
+  browserEncode
 } from './DOMUtils'
 
 const HashChangeEvent = 'hashchange'
@@ -83,7 +84,7 @@ const createHashHistory = (props = {}) => {
     if (basename)
       path = stripBasename(path, basename)
 
-    return createLocation(path)
+    return createLocation(path, undefined, undefined, undefined, browserEncode)
   }
 
   const transitionManager = createTransitionManager()
@@ -189,7 +190,7 @@ const createHashHistory = (props = {}) => {
     )
 
     const action = 'PUSH'
-    const location = createLocation(path, undefined, undefined, history.location)
+    const location = createLocation(path, undefined, undefined, history.location, browserEncode)
 
     transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
       if (!ok)
@@ -231,7 +232,7 @@ const createHashHistory = (props = {}) => {
     )
 
     const action = 'REPLACE'
-    const location = createLocation(path, undefined, undefined, history.location)
+    const location = createLocation(path, undefined, undefined, history.location, browserEncode)
 
     transitionManager.confirmTransitionTo(location, action, getUserConfirmation, (ok) => {
       if (!ok)


### PR DESCRIPTION
This is a followup to #516 and fixes #505. I don't know if this is the best solution, but I thought that I'd put it out there. I implemented the same thing in [hickory](https://github.com/pshrmn/hickory) and it does its job well.

This property is set prior to decoding the `pathname`. For browser and memory histories, the `rawPathname` will be the encoded version of the provided `pathname` (generated using an anchor element). For memory histories, the `rawPathname` is the same as the `pathname`.

When creating a URL (using `createPath`), the `rawPathname` property will be preferred over the `pathname` property.