### PR TITLE
feat($memoryHistory): add default getUserConfirmation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [v4.6.4]
+> Sep 5, 2017
+
+- add default `getUserConfirmation` option to `createMemoryHistory`, which throws if `window.confirm` is not available.
+
+[v4.6.4]: https://github.com/ReactTraining/history/compare/v4.6.3...v4.6.4
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -14,7 +14,7 @@ const getConfirmation = (message, callback) => {
   invariant(
     hasConfirm,
     'Environment needs a window + window.confirm function. You can provide' +
-    'your own confirmation UI via the getUserConfirmation option.' +
+    'your own confirmation UI via the getUserConfirmation option.'
   )
   
   return callback(window.confirm(message)) // eslint-disable-line no-alert

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -6,12 +6,26 @@ import createTransitionManager from './createTransitionManager'
 const clamp = (n, lowerBound, upperBound) =>
   Math.min(Math.max(n, lowerBound), upperBound)
 
+const hasConfirm = !!(
+  typeof window !== 'undefined' && typeof window.confirm !== 'undefined'
+)
+
+const getConfirmation = (message, callback) => {
+  invariant(
+    hasConfirm,
+    'Environment needs a window + window.confirm function. You can provide' +
+    'your own confirmation UI via the getUserConfirmation option.' +
+  )
+  
+  return callback(window.confirm(message)) // eslint-disable-line no-alert
+}
+
 /**
  * Creates a history object that stores locations in memory.
  */
 const createMemoryHistory = (props = {}) => {
   const {
-    getUserConfirmation,
+    getUserConfirmation = getConfirmation,
     initialEntries = [ '/' ],
     initialIndex = 0,
     keyLength = 6


### PR DESCRIPTION
Since memory history can be used in environments that have `window.confirm`, this PR provides a default option (like `createBrowserHistory`), but throws if `window.confirm` is not available.