### PR TITLE
Normalize browsers that fire a popstate event on load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [v4.7.3]
+> Sep 7, 2017
+
+- Normalize browser behavior by ignoring popstate on load present in Chrome (prior to v34) and Safari (prior to 10.0).
+
+[v4.7.3]: https://github.com/ReactTraining/history/compare/v4.6.3...v4.7.3
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,7 @@
 
 - Normalize browser behavior by ignoring popstate on load present in Chrome (prior to v34) and Safari (prior to 10.0).
 
-<<<<<<< HEAD
 [v4.7.3]: https://github.com/ReactTraining/history/compare/v4.6.3...v4.7.3
-=======
-[v4.6.4]: https://github.com/ReactTraining/history/compare/v4.7.3...v4.6.3
->>>>>>> 71e406d0e20b41121d80040bce3f6c0a78dd618b
 
 ## [v4.6.3]
 > Jun 20, 2017

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -88,6 +88,11 @@ const createBrowserHistory = (props = {}) => {
   }
 
   const handlePopState = (event) => {
+    // Ignore initial popstate present in Chrome (prior to v34) and Safari (prior to 10.0)
+    // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate
+    if (!event.state && allKeys.length === 1 && allKeys[0] === undefined)
+      return
+
     // Ignore extraneous popstate events in WebKit.
     if (isExtraneousPopstateEvent(event))
       return 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -32,6 +32,19 @@ const getHistoryState = () => {
   }
 }
 
+const normalizeInitialHistoryState = () => {
+  let historyState = window.history.state;
+  let url = window.location.href;
+
+  if (!historyState) {
+    try {
+      window.history.replaceState({}, window.document.title, url);
+    } catch (e) {
+      window.location.replace(url);
+    }
+  }
+}
+
 /**
  * Creates a history object that uses the HTML5 history API including
  * pushState, replaceState, and the popstate event.
@@ -90,12 +103,12 @@ const createBrowserHistory = (props = {}) => {
   const handlePopState = (event) => {
     // Ignore initial popstate present in Chrome (prior to v34) and Safari (prior to 10.0)
     // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate
-    if (!event.state && allKeys.length === 1 && allKeys[0] === undefined)
-      return
+    var stateFromHistory = (globalHistory && globalHistory.state) || null;
+    var isPageLoadPopState = (event.state === null) && !!stateFromHistory;
 
     // Ignore extraneous popstate events in WebKit.
-    if (isExtraneousPopstateEvent(event))
-      return 
+    if (isPageLoadPopState || isExtraneousPopstateEvent(event))
+      return
 
     handlePop(getDOMLocation(event.state))
   }
@@ -147,6 +160,8 @@ const createBrowserHistory = (props = {}) => {
       go(delta)
     }
   }
+
+  normalizeInitialHistoryState();
 
   const initialLocation = getDOMLocation(getHistoryState())
   let allKeys = [ initialLocation.key ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "history",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Manage session history with JavaScript",
   "repository": "ReactTraining/history",
   "license": "MIT",


### PR DESCRIPTION
> Browsers tend to handle the popstate event differently on page load. Chrome (prior to v34) and Safari (prior to 10.0) always emit a popstate event on page load, but Firefox doesn't.

— [MDN: WindowEventHandlers.onpopstate](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate)

Modern browsers that fired `popstate` on load no longer do so. Yahoo’s [fluxible-router](https://github.com/yahoo/fluxible/tree/master/packages/fluxible-router) features a wrapper around the History Web API and [normalized this behaviour across browsers](https://github.com/yahoo/fluxible/issues/349) by suppressing the event.

I’m not sure about the placement of my new additions, feel free to advise how I could integrate them better.

As Safari/WebKit exhibited this quirk #511 might be solved with these changes.