### PR TITLE
add type property to History objects

### DIFF
--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -136,6 +136,12 @@ describeHistory('a browser history', () => {
         TestSequences.BlockPopWithoutListening(history, done)
       })
     })
+
+    describe('type', () => {
+      it('has type BrowserHistory', () => {
+        expect(history.type).toEqual('BrowserHistory')
+      })
+    })
   })
 
   describe('that denies all transitions', () => {

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -139,6 +139,12 @@ describeHistory('a hash history', () => {
         TestSequences.BlockPopWithoutListening(history, done)
       })
     })
+
+    describe('type', () => {
+      it('has type HashHistory', () => {
+        expect(history.type).toEqual('HashHistory')
+      })
+    })
   })
 
   describe('that denies all transitions', () => {

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -1,3 +1,4 @@
+import expect from 'expect'
 import createHistory from '../createMemoryHistory'
 import * as TestSequences from './TestSequences'
 
@@ -125,6 +126,12 @@ describe('a memory history', () => {
     describe('block a POP without listening', () => {
       it('receives the next location and action as arguments', (done) => {
         TestSequences.BlockPopWithoutListening(history, done)
+      })
+    })
+
+    describe('type', () => {
+      it('has type MemoryHistory', () => {
+        expect(history.type).toEqual('MemoryHistory')
       })
     })
   })

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -90,7 +90,7 @@ const createBrowserHistory = (props = {}) => {
   const handlePopState = (event) => {
     // Ignore extraneous popstate events in WebKit.
     if (isExtraneousPopstateEvent(event))
-      return 
+      return
 
     handlePop(getDOMLocation(event.state))
   }
@@ -293,6 +293,7 @@ const createBrowserHistory = (props = {}) => {
   }
 
   const history = {
+    type: 'BrowserHistory',
     length: globalHistory.length,
     action: 'POP',
     location: initialLocation,

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -316,6 +316,7 @@ const createHashHistory = (props = {}) => {
   }
 
   const history = {
+    type: 'HashHistory',
     length: globalHistory.length,
     action: 'POP',
     location: initialLocation,

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -136,6 +136,7 @@ const createMemoryHistory = (props = {}) => {
     transitionManager.appendListener(listener)
 
   const history = {
+    type: 'MemoryHistory',
     length: entries.length,
     action: 'POP',
     location: entries[index],


### PR DESCRIPTION
This is a proposal to add a type property to history objects.

We have a need in our app to differentiate between memoryHistory and hashHistory, and thought it would generally be useful to have a property on the history objects which makes it easy to identify which type of history is in use.

What are your thoughts?
 