### PR TITLE
Prevent error when null is passed to push() or replace()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- **Bugfix:** Fix error thrown when passing `null` to `history.push` or `history.replace` ([#538])
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -153,7 +153,7 @@ const createBrowserHistory = (props = {}) => {
 
   const push = (path, state) => {
     warning(
-      !(typeof path === 'object' && path.state !== undefined && state !== undefined),
+      !(typeof path === 'object' && path !== null && path.state !== undefined && state !== undefined),
       'You should avoid providing a 2nd state argument to push when the 1st ' +
       'argument is a location-like object that already has state; it is ignored'
     )
@@ -195,7 +195,7 @@ const createBrowserHistory = (props = {}) => {
 
   const replace = (path, state) => {
     warning(
-      !(typeof path === 'object' && path.state !== undefined && state !== undefined),
+      !(typeof path === 'object' && path !== null && path.state !== undefined && state !== undefined),
       'You should avoid providing a 2nd state argument to replace when the 1st ' +
       'argument is a location-like object that already has state; it is ignored'
     )

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -46,7 +46,7 @@ const createMemoryHistory = (props = {}) => {
 
   const push = (path, state) => {
     warning(
-      !(typeof path === 'object' && path.state !== undefined && state !== undefined),
+      !(typeof path === 'object' && path !== null && path.state !== undefined && state !== undefined),
       'You should avoid providing a 2nd state argument to push when the 1st ' +
       'argument is a location-like object that already has state; it is ignored'
     )
@@ -79,7 +79,7 @@ const createMemoryHistory = (props = {}) => {
 
   const replace = (path, state) => {
     warning(
-      !(typeof path === 'object' && path.state !== undefined && state !== undefined),
+      !(typeof path === 'object' && path !== null && path.state !== undefined && state !== undefined),
       'You should avoid providing a 2nd state argument to replace when the 1st ' +
       'argument is a location-like object that already has state; it is ignored'
     )


### PR DESCRIPTION
Because `typeof null` evaluates to "object", it's possible that an error will be thrown when attempting to access `path.state` when the path is null. Adding an additional check for null ensures path is always an object before continuing through the conditional.

Fixes #510

Happy to add a test for this as well, but being that `null` isn't a normal value to pass in I wasn't sure if this warrants a test.