### PR TITLE
hasBasename bugfix

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -5,7 +5,7 @@ export const stripLeadingSlash = path =>
   path.charAt(0) === "/" ? path.substr(1) : path
 
 export const hasBasename = (path, prefix) =>
-  path.toLowerCase().lastIndexOf(prefix.toLowerCase(), 0) === 0 && "/?#".indexOf(path.charAt(prefix.length)) !== -1
+  path.toLowerCase().indexOf(prefix.toLowerCase()) === 0 && "/?#".indexOf(path.charAt(prefix.length)) !== -1
 
 export const stripBasename = (path, prefix) =>
   hasBasename(path, prefix) ? path.substr(prefix.length) : path

--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -5,7 +5,7 @@ export const stripLeadingSlash = path =>
   path.charAt(0) === "/" ? path.substr(1) : path
 
 export const hasBasename = (path, prefix) =>
-  new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path)
+  path.toLowerCase().lastIndexOf(prefix.toLowerCase(), 0) === 0 && "/?#".indexOf(path.charAt(prefix.length)) !== -1
 
 export const stripBasename = (path, prefix) =>
   hasBasename(path, prefix) ? path.substr(prefix.length) : path

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -270,7 +270,7 @@ describeHistory("a hash history", () => {
       expect(history.location.pathname).toEqual("/")
     })
 
-	it('allows URL with regex special characters', () => {
+    it('allows URL with regex special characters', () => {
       window.location.hash = '/prefix$special/hello'
       const history = createHistory({ basename: '/prefix$special'})
       expect(history.location.pathname).toEqual('/hello')

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -269,5 +269,11 @@ describeHistory("a hash history", () => {
       const history = createHistory({ basename: "/prefix" })
       expect(history.location.pathname).toEqual("/")
     })
+
+	it('allows URL with regex special characters', () => {
+      window.location.hash = '/prefix$special/hello'
+      const history = createHistory({ basename: '/prefix$special'})
+      expect(history.location.pathname).toEqual('/hello')
+    })
   })
 })


### PR DESCRIPTION
Previously it didn't work when `prefix` had special regex characters (eg `$`)