### PR TITLE
Fix history.listen triggered by initial page load on some old browsers

### DIFF
--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -42,9 +42,17 @@ export const supportsGoWithoutReloadUsingHash = () =>
   window.navigator.userAgent.indexOf("Firefox") === -1;
 
 /**
- * Returns true if a given popstate event is an extraneous WebKit event.
+ * Returns true if a given popstate event is an extraneous WebKit event, or it fired on initial page load.
  * Accounts for the fact that Chrome on iOS fires real popstate events
  * containing undefined state when pressing the back button.
  */
-export const isExtraneousPopstateEvent = event =>
-  event.state === undefined && navigator.userAgent.indexOf("CriOS") === -1;
+export const shouldIgnorePopstateEvent = (() => {
+  let loaded = false;
+  if (document.readyState === 'complete') {
+    loaded = true;
+  } else {
+    window.addEventListener('load', () => setTimeout(() => { loaded = true }));
+  }
+  return event =>
+    (event.state === undefined && navigator.userAgent.indexOf("CriOS") === -1) || !loaded;
+})();

--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -42,7 +42,8 @@ export const supportsGoWithoutReloadUsingHash = () =>
   window.navigator.userAgent.indexOf("Firefox") === -1;
 
 /**
- * Returns true if a given popstate event is an extraneous WebKit event, or it fired on initial page load.
+ * Returns true if a given popstate event is an extraneous WebKit event,
+ * or it fired on initial page load (the solution is from page.js [https://github.com/visionmedia/page.js]).
  * Accounts for the fact that Chrome on iOS fires real popstate events
  * containing undefined state when pressing the back button.
  */

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -14,7 +14,7 @@ import {
   getConfirmation,
   supportsHistory,
   supportsPopStateOnHashChange,
-  isExtraneousPopstateEvent
+  shouldIgnorePopstateEvent
 } from "./DOMUtils";
 
 const PopStateEvent = "popstate";
@@ -87,8 +87,7 @@ const createBrowserHistory = (props = {}) => {
   };
 
   const handlePopState = event => {
-    // Ignore extraneous popstate events in WebKit.
-    if (isExtraneousPopstateEvent(event)) return;
+    if (shouldIgnorePopstateEvent(event)) return;
 
     handlePop(getDOMLocation(event.state));
   };


### PR DESCRIPTION
Popstate event will fire after initial page load on some old browsers, like Safari on iOS 9. It will trigger history.listen.

This PR is a hack to fix this problem, the solution is from [page.js](https://github.com/visionmedia/page.js). I tested on iOS 9, it worked.