### PR TITLE
Allow ? character in basename for browser history.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## HEAD
+
+- Allow ? character to be used in basename for browser history (see [#564])
+
+[#564]: https://github.com/ReactTraining/history/issues/564
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -5,7 +5,7 @@ export const stripLeadingSlash = path =>
   path.charAt(0) === "/" ? path.substr(1) : path;
 
 export const hasBasename = (path, prefix) =>
-  new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path);
+  new RegExp("^" + prefix.replace("?", "\\?") + "(\\/|\\?|#|$)", "i").test(path);
 
 export const stripBasename = (path, prefix) =>
   hasBasename(path, prefix) ? path.substr(prefix.length) : path;

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -230,5 +230,11 @@ describeHistory("a browser history", () => {
       const history = createHistory({ basename: "/prefix" });
       expect(history.location.pathname).toEqual("/");
     });
+
+    it("handles ? character in basename correctly", () => {
+      window.history.replaceState(null, null, "/prefix?rest/pathname");
+      const history = createHistory({ basename: "/prefix?rest" });
+      expect(history.location.pathname).toEqual("/pathname");
+    });
   });
 });


### PR DESCRIPTION
When dealing with startup URL like http://example.com/index.html?foo, it
is not possible to define a basename like '/index.html?foo', the
basename matching utility does not escape regex special characters from
the specified prefix. This change escapes question mark characters,
likely the most common use case.