### PR TITLE
Fix hash replacement redirect

### DIFF
--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -45,11 +45,11 @@ const getHashPath = () => {
 const pushHashPath = path => (window.location.hash = path);
 
 const replaceHashPath = path => {
-  const hashIndex = window.location.href.indexOf("#");
+  let href = window.location.href;
+  const hashIndex = href.indexOf("#");
+  if (hashIndex !== -1) href = href.slice(0, hashIndex);
 
-  window.location.replace(
-    window.location.href.slice(0, hashIndex >= 0 ? hashIndex : 0) + "#" + path
-  );
+  window.location.replace(href + "#" + path);
 };
 
 const createHashHistory = (props = {}) => {


### PR DESCRIPTION
Fixes #574 dealing with `createHashHistory`'s support for the `<base>` tag. I didn't know how to simulate full-page refresh navigation in the tests but here's how you can manually test it:

Edit index.html to have `<base href="/the/base">` in the head and switch to hashHistory. Navigating to the local server without a hash at the end of the url will now redirect you to `http://localhost:8080/the/base/#/` in all browsers except for IE where it will redirect to `http://localhost:8080/#/`

With this change it always behaves as in IE, redirecting to `http://localhost:8080/#/` in all browsers.

I'll edit this shortly with a related PR for `createHref`.