### PR TITLE
Fix base tag hash history create href

### DIFF
--- a/modules/__tests__/createHref-test.js
+++ b/modules/__tests__/createHref-test.js
@@ -95,6 +95,13 @@ describe("a browser history", () => {
 });
 
 describe("a hash history", () => {
+  beforeEach(() => {
+    let base = document.querySelector("base");
+    if (base) {
+      base.removeAttribute("href");
+    }
+  });
+
   describe("with default encoding", () => {
     let history;
     beforeEach(() => {
@@ -191,6 +198,36 @@ describe("a hash history", () => {
       });
 
       expect(href).toEqual("#/the/path?the=query");
+    });
+  });
+
+  describe("with a <base> tag present in the page", () => {
+    let history;
+    beforeEach(() => {
+      let base = document.querySelector("base");
+      if (!base) {
+        base = document.createElement("base");
+        document.head.appendChild(base);
+      }
+      base.setAttribute("href", "/the/base/");
+
+      history = createHashHistory();
+    });
+
+    it("knows how to create hrefs", () => {
+      const hashIndex = window.location.href.indexOf("#");
+      const upToHash =
+        hashIndex === -1
+          ? window.location.href
+          : window.location.href.slice(0, hashIndex);
+
+      const href = history.createHref({
+        pathname: "/the/path",
+        search: "?the=query",
+        hash: "#the-hash"
+      });
+
+      expect(href).toEqual(upToHash + "#/the/path?the=query#the-hash");
     });
   });
 

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -34,6 +34,11 @@ const HashPathCoders = {
   }
 };
 
+const stripHash = url => {
+  const hashIndex = url.indexOf("#");
+  return hashIndex === -1 ? url : url.slice(0, hashIndex);
+};
+
 const getHashPath = () => {
   // We can't use window.location.hash here because it's not
   // consistent across browsers - Firefox will pre-decode it!
@@ -45,11 +50,7 @@ const getHashPath = () => {
 const pushHashPath = path => (window.location.hash = path);
 
 const replaceHashPath = path => {
-  let href = window.location.href;
-  const hashIndex = href.indexOf("#");
-  if (hashIndex !== -1) href = href.slice(0, hashIndex);
-
-  window.location.replace(href + "#" + path);
+  window.location.replace(stripHash(window.location.href) + "#" + path);
 };
 
 const createHashHistory = (props = {}) => {
@@ -173,8 +174,14 @@ const createHashHistory = (props = {}) => {
 
   // Public interface
 
-  const createHref = location =>
-    "#" + encodePath(basename + createPath(location));
+  const createHref = location => {
+    const baseTag = document.querySelector("base");
+    let href = "";
+    if (baseTag && baseTag.getAttribute("href")) {
+      href = stripHash(window.location.href);
+    }
+    return href + "#" + encodePath(basename + createPath(location));
+  };
 
   const push = (path, state) => {
     warning(

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -45,11 +45,11 @@ const getHashPath = () => {
 const pushHashPath = path => (window.location.hash = path);
 
 const replaceHashPath = path => {
-  const hashIndex = window.location.href.indexOf("#");
+  let href = window.location.href;
+  const hashIndex = href.indexOf("#");
+  if (hashIndex !== -1) href = href.slice(0, hashIndex);
 
-  window.location.replace(
-    window.location.href.slice(0, hashIndex >= 0 ? hashIndex : 0) + "#" + path
-  );
+  window.location.replace(href + "#" + path);
 };
 
 const createHashHistory = (props = {}) => {


### PR DESCRIPTION
This is related to #577. This changes `createHashHistory`'s `createHref` to produce absolute URLs only when a `<base>` tag is present on the page. It works like this:

```javascript
const loc = {
  pathname: "/the/path",
  search: "?the=query",
  hash: "#the-hash"
}

// no base tag present on page
history.createHref(loc)
// -> "#/the/path?the=query#the-hash"

// base tag present with non-empty href
history.createHref(loc)
// -> "<part of current url up to hash>#/the/path?the=query#the-hash"
```

The net effect of this will be to allow the browser to correctly mark links as visited.

This is because, when a base tag is present, the relative hash url will point relative to the base as far as the browser is concerned ( e.g. `"/the/base/#/the/path?the=query#the-hash"`) while a history push to that location will do the right thing and update the href to `"<part of current url up to hash>#/the/path?the=query#the-hash"` ignoring the base.

So when history is used in `HashRouter` for example, clicking a link will update the location correctly but it won't get marked as visited from the browser. Producing absolute URLs from `createHref` when the base tag is present fixes this. Always creating absolute URLs from `createHref` would make the code and tests a bit simpler, but I thought only doing it when a base tag is present was less obtrusive. Let me know what you think.