### PR TITLE
Add params function to browser & memory history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [v4.6.4]
+> Jun 20, 2017
+
+- Add params function to browser & memory history
+
+This feature allows developers to easily access URL params on the current location by calling `history.params(‘foo’)` or `history.params()`. 
+
+[v4.6.4]: https://github.com/ReactTraining/history/compare/v4.6.3...v4.6.4
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -231,4 +231,24 @@ describeHistory("a browser history", () => {
       expect(history.location.pathname).toEqual("/");
     });
   });
+
+  describe("params", () => {
+    it("returns all params as object when called with no args", () => {
+      const history = createHistory();
+      history.replace("/?a=foo&b=bar&c=1234");
+      expect(history.params()).toEqual({
+        a: 'foo',
+        b: 'bar',
+        c: '1234',
+      });
+    });
+
+    it("returns param as a string from location search", () => {
+      const history = createHistory();
+      history.replace("/?a=foo&b=bar&c=1234");
+      expect(history.params('a')).toEqual('foo');
+      expect(history.params('b')).toEqual('bar');
+      expect(history.params('c')).toEqual('1234');
+    });
+  });
 });

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -1,3 +1,4 @@
+import expect from "expect";
 import createHistory from "../createMemoryHistory";
 import * as TestSequences from "./TestSequences";
 
@@ -174,6 +175,26 @@ describe("a memory history", () => {
 
     it("cancels the transition when it returns false", done => {
       TestSequences.ReturnFalseTransitionHook(history, done);
+    });
+  });
+
+  describe("params", () => {
+    it("returns all params as object when called with no args", () => {
+      const history = createHistory();
+      history.replace("/?a=foo&b=bar&c=1234");
+      expect(history.params()).toEqual({
+        a: 'foo',
+        b: 'bar',
+        c: '1234',
+      });
+    });
+
+    it("returns param as a string from location search", () => {
+      const history = createHistory();
+      history.replace("/?a=foo&b=bar&c=1234");
+      expect(history.params('a')).toEqual('foo');
+      expect(history.params('b')).toEqual('bar');
+      expect(history.params('c')).toEqual('1234');
     });
   });
 });

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -1,5 +1,6 @@
 import warning from "warning";
 import invariant from "invariant";
+import qs from "qs";
 import { createLocation } from "./LocationUtils";
 import {
   addLeadingSlash,
@@ -308,6 +309,13 @@ const createBrowserHistory = (props = {}) => {
     };
   };
 
+  const params = (param = null) => {
+    const obj = qs.parse(history.location.search.replace('?', ''));
+    if (param)
+      return obj[param];
+    return obj;
+  }
+
   const history = {
     length: globalHistory.length,
     action: "POP",
@@ -319,7 +327,8 @@ const createBrowserHistory = (props = {}) => {
     goBack,
     goForward,
     block,
-    listen
+    listen,
+    params
   };
 
   return history;

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -1,4 +1,5 @@
 import warning from "warning";
+import qs from "qs";
 import { createPath } from "./PathUtils";
 import { createLocation } from "./LocationUtils";
 import createTransitionManager from "./createTransitionManager";
@@ -156,6 +157,13 @@ const createMemoryHistory = (props = {}) => {
 
   const listen = listener => transitionManager.appendListener(listener);
 
+  const params = (param = null) => {
+    const obj = qs.parse(history.location.search.replace('?', ''));
+    if (param)
+      return obj[param];
+    return obj;
+  }
+
   const history = {
     length: entries.length,
     action: "POP",
@@ -170,7 +178,8 @@ const createMemoryHistory = (props = {}) => {
     goForward,
     canGo,
     block,
-    listen
+    listen,
+    params
   };
 
   return history;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "invariant": "^2.2.1",
     "loose-envify": "^1.2.0",
+    "qs": "^6.5.1",
     "resolve-pathname": "^2.2.0",
     "value-equal": "^0.4.0",
     "warning": "^3.0.0"


### PR DESCRIPTION
Hello! Recently I have been finding it useful to extend the history object with a params function, so I can easily retrieve the current URL params or a single param. I thought I would add it into the library itself to see if you guys think its useful. 

#### Summary

This feature allows developers to easily access URL params on the current location by calling `history.params(‘foo’)` or `history.params()`.