### PR TITLE
Expose and use action constants

### DIFF
--- a/modules/constants.js
+++ b/modules/constants.js
@@ -1,0 +1,3 @@
+export const POP = "POP";
+export const PUSH = "PUSH";
+export const REPLACE = "REPLACE";

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -16,6 +16,11 @@ import {
   supportsPopStateOnHashChange,
   isExtraneousPopstateEvent
 } from "./DOMUtils";
+import {
+  POP,
+  PUSH,
+  REPLACE
+} from "./constants";
 
 const PopStateEvent = "popstate";
 const HashChangeEvent = "hashchange";
@@ -104,7 +109,7 @@ const createBrowserHistory = (props = {}) => {
       forceNextPop = false;
       setState();
     } else {
-      const action = "POP";
+      const action = POP;
 
       transitionManager.confirmTransitionTo(
         location,
@@ -162,7 +167,7 @@ const createBrowserHistory = (props = {}) => {
         "argument is a location-like object that already has state; it is ignored"
     );
 
-    const action = "PUSH";
+    const action = PUSH;
     const location = createLocation(path, state, createKey(), history.location);
 
     transitionManager.confirmTransitionTo(
@@ -215,7 +220,7 @@ const createBrowserHistory = (props = {}) => {
         "argument is a location-like object that already has state; it is ignored"
     );
 
-    const action = "REPLACE";
+    const action = REPLACE;
     const location = createLocation(path, state, createKey(), history.location);
 
     transitionManager.confirmTransitionTo(
@@ -310,7 +315,7 @@ const createBrowserHistory = (props = {}) => {
 
   const history = {
     length: globalHistory.length,
-    action: "POP",
+    action: POP,
     location: initialLocation,
     createHref,
     push,

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -15,6 +15,11 @@ import {
   getConfirmation,
   supportsGoWithoutReloadUsingHash
 } from "./DOMUtils";
+import {
+  POP,
+  PUSH,
+  REPLACE
+} from "./constants";
 
 const HashChangeEvent = "hashchange";
 
@@ -122,7 +127,7 @@ const createHashHistory = (props = {}) => {
       forceNextPop = false;
       setState();
     } else {
-      const action = "POP";
+      const action = POP;
 
       transitionManager.confirmTransitionTo(
         location,
@@ -182,7 +187,7 @@ const createHashHistory = (props = {}) => {
       "Hash history cannot push state; it is ignored"
     );
 
-    const action = "PUSH";
+    const action = PUSH;
     const location = createLocation(
       path,
       undefined,
@@ -236,7 +241,7 @@ const createHashHistory = (props = {}) => {
       "Hash history cannot replace state; it is ignored"
     );
 
-    const action = "REPLACE";
+    const action = REPLACE;
     const location = createLocation(
       path,
       undefined,
@@ -329,7 +334,7 @@ const createHashHistory = (props = {}) => {
 
   const history = {
     length: globalHistory.length,
-    action: "POP",
+    action: POP,
     location: initialLocation,
     createHref,
     push,

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -2,6 +2,11 @@ import warning from "warning";
 import { createPath } from "./PathUtils";
 import { createLocation } from "./LocationUtils";
 import createTransitionManager from "./createTransitionManager";
+import {
+  POP,
+  PUSH,
+  REPLACE
+} from "./constants";
 
 const clamp = (n, lowerBound, upperBound) =>
   Math.min(Math.max(n, lowerBound), upperBound);
@@ -55,7 +60,7 @@ const createMemoryHistory = (props = {}) => {
         "argument is a location-like object that already has state; it is ignored"
     );
 
-    const action = "PUSH";
+    const action = PUSH;
     const location = createLocation(path, state, createKey(), history.location);
 
     transitionManager.confirmTransitionTo(
@@ -100,7 +105,7 @@ const createMemoryHistory = (props = {}) => {
         "argument is a location-like object that already has state; it is ignored"
     );
 
-    const action = "REPLACE";
+    const action = REPLACE;
     const location = createLocation(path, state, createKey(), history.location);
 
     transitionManager.confirmTransitionTo(
@@ -120,7 +125,7 @@ const createMemoryHistory = (props = {}) => {
   const go = n => {
     const nextIndex = clamp(history.index + n, 0, history.entries.length - 1);
 
-    const action = "POP";
+    const action = POP;
     const location = history.entries[nextIndex];
 
     transitionManager.confirmTransitionTo(
@@ -158,7 +163,7 @@ const createMemoryHistory = (props = {}) => {
 
   const history = {
     length: entries.length,
-    action: "POP",
+    action: POP,
     location: entries[index],
     index,
     entries,

--- a/modules/index.js
+++ b/modules/index.js
@@ -3,3 +3,4 @@ export createHashHistory from "./createHashHistory";
 export createMemoryHistory from "./createMemoryHistory";
 export { createLocation, locationsAreEqual } from "./LocationUtils";
 export { parsePath, createPath } from "./PathUtils";
+export { POP, PUSH, REPLACE } from './constants';


### PR DESCRIPTION
Hello! In an application of mine I'm comparing the action of state transitions with plain strings. I think it would be nice if the library exported the action strings as constants so users of the library could use them.

**Summary**
This feature allows developers to import the constants `POP`, `PUSH` and `REPLACE` from the history package. `import { POP, PUSH, REPLACE } from 'history';`