### PR TITLE
Escape prefix value in hasBasename

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -7,7 +7,7 @@ export function stripLeadingSlash(path) {
 }
 
 export function hasBasename(path, prefix) {
-  return new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path);
+  return new RegExp("^" + prefix.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&') + "(\\/|\\?|#|$)", "i").test(path);
 }
 
 export function stripBasename(path, prefix) {

--- a/modules/__tests__/PathUtils-test.js
+++ b/modules/__tests__/PathUtils-test.js
@@ -1,0 +1,78 @@
+import expect from "expect";
+import { hasBasename, stripBasename } from "../PathUtils";
+
+describe("hasBasename", () => {
+  describe("with a simple path", () => {
+    const basepath = '/prefix/with'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(hasBasename(`${basepath}/some/url/path`, basepath)).toBeTruthy();
+      });
+    });
+
+    describe("given as a url without basename", () => {
+      it("returns false", () => {
+        expect(hasBasename(`/some/url/path`, basepath)).toBeFalsy();
+      });
+    });
+  });
+
+  describe("with a hash value", () => {
+    const basepath = '/prefix/with#/'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(hasBasename(`${basepath}/some/url/path`, basepath)).toBeTruthy();
+      });
+    });
+
+    describe("given as a url without basename", () => {
+      it("returns false", () => {
+        expect(hasBasename(`/some/url/path`, basepath)).toBeFalsy();
+      });
+    });
+  });
+
+  describe("with a search value", () => {
+    const basepath = '/prefix/with?search'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(hasBasename(`${basepath}/some/url/path`, basepath)).toBeTruthy();
+      });
+    });
+
+    describe("given as a url without basename", () => {
+      it("returns false", () => {
+        expect(hasBasename(`/some/url/path`, basepath)).toBeFalsy();
+      });
+    });
+  });
+});
+
+describe("stripBasename", () => {
+  describe("with a simple path", () => {
+    const basepath = '/prefix/with'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(stripBasename(`${basepath}/some/url/path`, '/some/url/path')).toBeTruthy();
+      });
+    });
+  });
+
+  describe("with a hash value", () => {
+    const basepath = '/prefix/with#/'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(stripBasename(`${basepath}/some/url/path`, '/some/url/path')).toBeTruthy();
+      });
+    });
+  });
+
+  describe("with a search value", () => {
+    const basepath = '/prefix/with?search'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(stripBasename(`${basepath}/some/url/path`, '/some/url/path')).toBeTruthy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/ReactTraining/history/issues/564

- Adds tests for `PathUtils.hasBasename` and `PathUtils.stripBasename`
  - "hasBasename with a search value given as a url with basename returns true" fails
- Escapes these characters when creating RegExp in `hasBasename`: `| \ { } ( ) [ ] ^ $ + * ? .` 
  - "hasBasename with a search value given as a url with basename returns true" now passes

This PR fixes `PathUtils.hasBasename` so that it correctly handles special URL characters. This allows users to specify a basename that contains a search params and other special regex characters and have it both correctly match and correctly strip the basename from the path.

This is helpful when you want to be able to ignore everything in the URL up to a given point. For example, given the URL `/basepath/app?search=params&to=ignore#/real/path/to/parse`, you may only care about `/real/path/to/parse`. Providing a basename value of `/basepath/app?search=params&to=ignore#/` would not previously work, because the `?` was not escaped, so the produced RegExp in `hasBasename` would not match correctly.

This could be considered a breaking change if you were relying on the internal checking mechanism to use a regex pattern instead of a string. However, given that the docs specifically call for the basename value to be a *string*, I'd consider that an incorrect use of the basename value in the first place. From the README (emphasis mine):

> If all the URLs in your app are relative to some other "base" URL, use the basename option. This option transparently adds **the given string** to the front of all URLs you use.

*Aside*: The contributing guide says to add a note to CHANGES.md, but it seems that hasn't been done since `v4.6.3`, so I skipped that step... looks like most recent PRs haven't done this either.