### PR TITLE
Escape prefix value in hasBasename

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -5,7 +5,7 @@ export const stripLeadingSlash = path =>
   path.charAt(0) === "/" ? path.substr(1) : path;
 
 export const hasBasename = (path, prefix) =>
-  new RegExp("^" + prefix.replace(/(\?)/g, '\\$1') + "(\\/|\\?|#|$)", "i").test(path);
+  new RegExp("^" + prefix.replace(/([\[\]|?])/g, '\\$1') + "(\\/|\\?|#|$)", "i").test(path);
 
 export const stripBasename = (path, prefix) =>
   hasBasename(path, prefix) ? path.substr(prefix.length) : path;

--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -5,7 +5,7 @@ export const stripLeadingSlash = path =>
   path.charAt(0) === "/" ? path.substr(1) : path;
 
 export const hasBasename = (path, prefix) =>
-  new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path);
+  new RegExp("^" + prefix.replace(/(\?)/g, '\\$1') + "(\\/|\\?|#|$)", "i").test(path);
 
 export const stripBasename = (path, prefix) =>
   hasBasename(path, prefix) ? path.substr(prefix.length) : path;

--- a/modules/__tests__/PathUtils-test.js
+++ b/modules/__tests__/PathUtils-test.js
@@ -1,0 +1,78 @@
+import expect from "expect";
+import { hasBasename, stripBasename } from "../PathUtils";
+
+describe("hasBasename", () => {
+  describe("with a simple path", () => {
+    const basepath = '/prefix/with'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(hasBasename(`${basepath}/some/url/path`, basepath)).toBeTruthy();
+      });
+    });
+
+    describe("given as a url without basename", () => {
+      it("returns false", () => {
+        expect(hasBasename(`/some/url/path`, basepath)).toBeFalsy();
+      });
+    });
+  });
+
+  describe("with a hash value", () => {
+    const basepath = '/prefix/with#/'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(hasBasename(`${basepath}/some/url/path`, basepath)).toBeTruthy();
+      });
+    });
+
+    describe("given as a url without basename", () => {
+      it("returns false", () => {
+        expect(hasBasename(`/some/url/path`, basepath)).toBeFalsy();
+      });
+    });
+  });
+
+  describe("with a search value", () => {
+    const basepath = '/prefix/with?search'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(hasBasename(`${basepath}/some/url/path`, basepath)).toBeTruthy();
+      });
+    });
+
+    describe("given as a url without basename", () => {
+      it("returns false", () => {
+        expect(hasBasename(`/some/url/path`, basepath)).toBeFalsy();
+      });
+    });
+  });
+});
+
+describe("stripBasename", () => {
+  describe("with a simple path", () => {
+    const basepath = '/prefix/with'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(stripBasename(`${basepath}/some/url/path`, '/some/url/path')).toBeTruthy();
+      });
+    });
+  });
+
+  describe("with a hash value", () => {
+    const basepath = '/prefix/with#/'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(stripBasename(`${basepath}/some/url/path`, '/some/url/path')).toBeTruthy();
+      });
+    });
+  });
+
+  describe("with a search value", () => {
+    const basepath = '/prefix/with?search'
+    describe("given as a url with basename", () => {
+      it("returns true", () => {
+        expect(stripBasename(`${basepath}/some/url/path`, '/some/url/path')).toBeTruthy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
 fix: hasBasename handles search and additional special characters correctly

escape the ? [, ] and | character before using it in the regexp instantiation