### PR TITLE
Escape basename before interpreting as Regex

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -1,3 +1,5 @@
+import escapeStringRegexp from 'escape-string-regexp';
+
 export const addLeadingSlash = path =>
   path.charAt(0) === "/" ? path : "/" + path;
 
@@ -5,7 +7,7 @@ export const stripLeadingSlash = path =>
   path.charAt(0) === "/" ? path.substr(1) : path;
 
 export const hasBasename = (path, prefix) =>
-  new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path);
+  new RegExp("^" + escapeStringRegexp(prefix) + "(\\/|\\?|#|$)", "i").test(path);
 
 export const stripBasename = (path, prefix) =>
   hasBasename(path, prefix) ? path.substr(prefix.length) : path;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "escape-string-regexp": "^1.0.5",
     "invariant": "^2.2.1",
     "loose-envify": "^1.2.0",
     "resolve-pathname": "^2.2.0",


### PR DESCRIPTION
Fixes #605 

If you'd rather not introduce a new dependency, I'm open to suggestions, but `escape-string-regexp` is literally 11 lines of code.

https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js