### PR TITLE
Allow getUserConfirmation callback result to cater for any type of value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- Allow `getUserConfirmation` callback result to cater for any type of value ([#489])
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -26,24 +26,23 @@ const createTransitionManager = () => {
       const result =
         typeof prompt === "function" ? prompt(location, action) : prompt;
 
-      if (typeof result === "string") {
+      if (typeof result === "boolean") {
+        // Return false from a transition hook to cancel the transition.
+        callback(result);
+        return
+      } else if (result)  {
         if (typeof getUserConfirmation === "function") {
           getUserConfirmation(result, callback);
+          return
         } else {
           warning(
             false,
             "A history needs a getUserConfirmation function in order to use a prompt message"
           );
-
-          callback(true);
         }
-      } else {
-        // Return false from a transition hook to cancel the transition.
-        callback(result !== false);
       }
-    } else {
-      callback(true);
     }
+    callback(true);
   };
 
   let listeners = [];


### PR DESCRIPTION
Closes #489

We'd like to have a multi-option confirmation popup (save/discard/cancel) and need a way to pass additional details about the actions, and an action handler into getUserConfirmation.

The changes proposed will not break break compatibility but will allow for any type of value returned from the callback.