### PR TITLE
Encoding changes

### DIFF
--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -2,7 +2,7 @@ import resolvePathname from "resolve-pathname";
 import valueEqual from "value-equal";
 import { parsePath } from "./PathUtils";
 
-export const createLocation = (path, state, key, currentLocation) => {
+export const createLocation = (path, state, key, currentLocation, decodePath = decodeURI) => {
   let location;
   if (typeof path === "string") {
     // Two-arg form: push(path, state)
@@ -32,7 +32,7 @@ export const createLocation = (path, state, key, currentLocation) => {
   }
 
   try {
-    location.pathname = decodeURI(location.pathname);
+    location.pathname = decodePath(location.pathname);
   } catch (e) {
     if (e instanceof URIError) {
       throw new URIError(

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -323,7 +323,7 @@ describeHistory("a browser history", () => {
     });
 
     describe("pushState", () => {
-      it("passes original path prefixed with basename", () => {
+      it("passes original path string", () => {
         const pushState = window.history.pushState;
         window.history.pushState = jestMock.fn();
 
@@ -337,10 +337,28 @@ describeHistory("a browser history", () => {
 
         window.history.pushState = pushState;
       });
+
+      it("passes path derived from original path object", () => {
+        const pushState = window.history.pushState;
+        window.history.pushState = jestMock.fn();
+
+        const pathname = encodeURI("/abc %");
+        const search = "?some=query";
+        const hash = "#some=fragment";
+
+        history.push({ pathname, search, hash });
+        expect(window.history.pushState).toHaveBeenCalledWith(
+          expect.anything(), /* state */
+          null, /* title */
+          "/prefix" + pathname + search + hash
+        );
+
+        window.history.pushState = pushState;
+      });
     });
 
     describe("replaceState", () => {
-      it("passes original path prefixed with basename", () => {
+      it("passes original path string", () => {
         const replaceState = window.history.replaceState;
         window.history.replaceState = jestMock.fn();
 
@@ -350,6 +368,24 @@ describeHistory("a browser history", () => {
           expect.anything(), /* state */
           null, /* title */
           "/prefix" + path
+        );
+
+        window.history.replaceState = replaceState;
+      });
+
+      it("passes path derived from original path object", () => {
+        const replaceState = window.history.replaceState;
+        window.history.replaceState = jestMock.fn();
+
+        const pathname = encodeURI("/abc %");
+        const search = "?some=query";
+        const hash = "#some=fragment";
+
+        history.replace({ pathname, search, hash });
+        expect(window.history.replaceState).toHaveBeenCalledWith(
+          expect.anything(), /* state */
+          null, /* title */
+          "/prefix" + pathname + search + hash
         );
 
         window.history.replaceState = replaceState;

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -1,4 +1,5 @@
 import expect from "expect";
+import jestMock from "jest-mock";
 import createHistory from "../createBrowserHistory";
 import { canUseDOM, supportsHistory } from "../DOMUtils";
 import * as TestSequences from "./TestSequences";
@@ -311,6 +312,47 @@ describeHistory("a browser history", () => {
     describe("location created by encoded and unencoded pathname", () => {
       it("produces the same location.pathname", done => {
         TestSequences.LocationPathnameAlwaysDecoded(history, done);
+      });
+    });
+  });
+
+  describe("href passed to global history", () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory({ basename: "/prefix" });
+    });
+
+    describe("pushState", () => {
+      it("passes original path prefixed with basename", () => {
+        const pushState = window.history.pushState;
+        window.history.pushState = jestMock.fn();
+
+        const path = encodeURI("/abc %");
+        history.push(path);
+        expect(window.history.pushState).toHaveBeenCalledWith(
+          expect.anything(), /* state */
+          null, /* title */
+          "/prefix" + path
+        );
+
+        window.history.pushState = pushState;
+      });
+    });
+
+    describe("replaceState", () => {
+      it("passes original path prefixed with basename", () => {
+        const replaceState = window.history.replaceState;
+        window.history.replaceState = jestMock.fn();
+
+        const path = encodeURI("/abc %");
+        history.replace(path);
+        expect(window.history.replaceState).toHaveBeenCalledWith(
+          expect.anything(), /* state */
+          null, /* title */
+          "/prefix" + path
+        );
+
+        window.history.replaceState = replaceState;
       });
     });
   });

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -231,4 +231,87 @@ describeHistory("a browser history", () => {
       expect(history.location.pathname).toEqual("/");
     });
   });
+
+  describe("with specified decodePath", () => {
+    const decodePath = decodeURIComponent;
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        decodePath
+      });
+    });
+
+    it("decodes with provided function", () => {
+      const path = "/" + encodeURIComponent("abc ;,/?:@&=+$#");
+      history.push(path);
+      expect(history.location.pathname).not.toEqual(decodeURI(path));
+      expect(history.location.pathname).toEqual(decodePath(path));
+    });
+
+    describe("push a new path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.PushNewLocation(history, done);
+      });
+    });
+
+    describe("push the same path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.PushSamePath(history, done);
+      });
+    });
+
+    describe("push with no pathname", () => {
+      it("calls change listeners with the normalized location", done => {
+        TestSequences.PushMissingPathname(history, done);
+      });
+    });
+
+    describe("push with a relative pathname", () => {
+      it("calls change listeners with the normalized location", done => {
+        TestSequences.PushRelativePathname(history, done);
+      });
+    });
+
+    describe("push with a unicode path string", () => {
+      it("creates a location with decoded properties", done => {
+        TestSequences.PushUnicodeLocation(history, done);
+      });
+    });
+
+    describe("push with an encoded path string", () => {
+      it("creates a location object with decoded pathname", done => {
+        TestSequences.PushEncodedLocation(history, done);
+      });
+    });
+
+    describe("push with an invalid path string (bad percent-encoding)", () => {
+      it("throws an error", done => {
+        TestSequences.PushInvalidPathname(history, done);
+      });
+    });
+
+    describe("replace a new path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.ReplaceNewLocation(history, done);
+      });
+    });
+
+    describe("replace the same path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.ReplaceSamePath(history, done);
+      });
+    });
+
+    describe("replace  with an invalid path string (bad percent-encoding)", () => {
+      it("throws an error", done => {
+        TestSequences.ReplaceInvalidPathname(history, done);
+      });
+    });
+
+    describe("location created by encoded and unencoded pathname", () => {
+      it("produces the same location.pathname", done => {
+        TestSequences.LocationPathnameAlwaysDecoded(history, done);
+      });
+    });
+  });
 });

--- a/modules/__tests__/LocationUtils-test.js
+++ b/modules/__tests__/LocationUtils-test.js
@@ -148,6 +148,21 @@ describe("createLocation", () => {
     });
   });
 
+  describe("decodePath", () => {
+    const path = encodeURI("/abc %");
+
+    it("decodes path defaulting to decodeURI", () => {  
+      expect(createLocation(path)).toHaveProperty("pathname", decodeURI(path));
+    })
+
+    it("decodes path with provided function", () => {
+      const decodePath = x => x;
+      expect(
+        createLocation(path, undefined, undefined, undefined, decodePath)
+      ).toHaveProperty("pathname",path)
+    })
+  })
+
   describe("key", () => {
     it("has a key property if a key is provided", () => {
       const location = createLocation("/the/path", undefined, "key");

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -1,3 +1,4 @@
+import expect from "expect";
 import createHistory from "../createMemoryHistory";
 import * as TestSequences from "./TestSequences";
 
@@ -174,6 +175,90 @@ describe("a memory history", () => {
 
     it("cancels the transition when it returns false", done => {
       TestSequences.ReturnFalseTransitionHook(history, done);
+    });
+  });
+
+
+  describe("with specified decodePath", () => {
+    const decodePath = decodeURIComponent;
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        decodePath
+      });
+    });
+
+    it("decodes with provided function", () => {
+      const path = "/" + encodeURIComponent("abc ;,/?:@&=+$#");
+      history.push(path);
+      expect(history.location.pathname).not.toEqual(decodeURI(path));
+      expect(history.location.pathname).toEqual(decodePath(path));
+    });
+
+    describe("push a new path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.PushNewLocation(history, done);
+      });
+    });
+
+    describe("push the same path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.PushSamePath(history, done);
+      });
+    });
+
+    describe("push with no pathname", () => {
+      it("calls change listeners with the normalized location", done => {
+        TestSequences.PushMissingPathname(history, done);
+      });
+    });
+
+    describe("push with a relative pathname", () => {
+      it("calls change listeners with the normalized location", done => {
+        TestSequences.PushRelativePathname(history, done);
+      });
+    });
+
+    describe("push with a unicode path string", () => {
+      it("creates a location with decoded properties", done => {
+        TestSequences.PushUnicodeLocation(history, done);
+      });
+    });
+
+    describe("push with an encoded path string", () => {
+      it("creates a location object with decoded pathname", done => {
+        TestSequences.PushEncodedLocation(history, done);
+      });
+    });
+
+    describe("push with an invalid path string (bad percent-encoding)", () => {
+      it("throws an error", done => {
+        TestSequences.PushInvalidPathname(history, done);
+      });
+    });
+
+    describe("replace a new path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.ReplaceNewLocation(history, done);
+      });
+    });
+
+    describe("replace the same path", () => {
+      it("calls change listeners with the new location", done => {
+        TestSequences.ReplaceSamePath(history, done);
+      });
+    });
+
+    describe("replace  with an invalid path string (bad percent-encoding)", () => {
+      it("throws an error", done => {
+        TestSequences.ReplaceInvalidPathname(history, done);
+      });
+    });
+
+    describe("location created by encoded and unencoded pathname", () => {
+      it("produces the same location.pathname", done => {
+        TestSequences.LocationPathnameAlwaysDecoded(history, done);
+      });
     });
   });
 });

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -173,7 +173,7 @@ const createBrowserHistory = (props = {}) => {
       ok => {
         if (!ok) return;
 
-        const href = createHref(location);
+        const href = basename + path;
         const { key, state } = location;
 
         if (canUseHistory) {
@@ -226,7 +226,7 @@ const createBrowserHistory = (props = {}) => {
       ok => {
         if (!ok) return;
 
-        const href = createHref(location);
+        const href = basename + path;
         const { key, state } = location;
 
         if (canUseHistory) {

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -44,7 +44,8 @@ const createBrowserHistory = (props = {}) => {
   const {
     forceRefresh = false,
     getUserConfirmation = getConfirmation,
-    keyLength = 6
+    keyLength = 6,
+    decodePath,
   } = props;
   const basename = props.basename
     ? stripTrailingSlash(addLeadingSlash(props.basename))
@@ -68,7 +69,7 @@ const createBrowserHistory = (props = {}) => {
 
     if (basename) path = stripBasename(path, basename);
 
-    return createLocation(path, state, key);
+    return createLocation(path, state, key, null, decodePath);
   };
 
   const createKey = () =>
@@ -163,7 +164,7 @@ const createBrowserHistory = (props = {}) => {
     );
 
     const action = "PUSH";
-    const location = createLocation(path, state, createKey(), history.location);
+    const location = createLocation(path, state, createKey(), history.location, decodePath);
 
     transitionManager.confirmTransitionTo(
       location,
@@ -216,7 +217,7 @@ const createBrowserHistory = (props = {}) => {
     );
 
     const action = "REPLACE";
-    const location = createLocation(path, state, createKey(), history.location);
+    const location = createLocation(path, state, createKey(), history.location, decodePath);
 
     transitionManager.confirmTransitionTo(
       location,

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -173,7 +173,7 @@ const createBrowserHistory = (props = {}) => {
       ok => {
         if (!ok) return;
 
-        const href = basename + path;
+        const href = basename + (typeof path === "string" ? path : createPath(path));
         const { key, state } = location;
 
         if (canUseHistory) {
@@ -226,7 +226,7 @@ const createBrowserHistory = (props = {}) => {
       ok => {
         if (!ok) return;
 
-        const href = basename + path;
+        const href = basename + (typeof path === "string" ? path : createPath(path));
         const { key, state } = location;
 
         if (canUseHistory) {

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -14,7 +14,8 @@ const createMemoryHistory = (props = {}) => {
     getUserConfirmation,
     initialEntries = ["/"],
     initialIndex = 0,
-    keyLength = 6
+    keyLength = 6,
+    decodePath,
   } = props;
 
   const transitionManager = createTransitionManager();
@@ -36,8 +37,8 @@ const createMemoryHistory = (props = {}) => {
   const entries = initialEntries.map(
     entry =>
       typeof entry === "string"
-        ? createLocation(entry, undefined, createKey())
-        : createLocation(entry, undefined, entry.key || createKey())
+        ? createLocation(entry, undefined, createKey(), undefined, decodePath)
+        : createLocation(entry, undefined, entry.key || createKey(), undefined, decodePath)
   );
 
   // Public interface
@@ -56,7 +57,7 @@ const createMemoryHistory = (props = {}) => {
     );
 
     const action = "PUSH";
-    const location = createLocation(path, state, createKey(), history.location);
+    const location = createLocation(path, state, createKey(), history.location, decodePath);
 
     transitionManager.confirmTransitionTo(
       location,
@@ -101,7 +102,7 @@ const createMemoryHistory = (props = {}) => {
     );
 
     const action = "REPLACE";
-    const location = createLocation(path, state, createKey(), history.location);
+    const location = createLocation(path, state, createKey(), history.location, decodePath);
 
     transitionManager.confirmTransitionTo(
       location,


### PR DESCRIPTION
This includes two changes:

1. Adds configurable decode path function. The library currently uses `decodeURI()` in `createLocation()`, but this only works with strings encoded with `encodeURI()`. Otherwise it can leave the path partially decoded. The configuration option is called `decodePath` and is specified when creating a history object.

2. Passes original encoded path to browser (when `push()`-ing or `replace()`-ing). Currently the decoded path is used, depending on the browser to re-encode the URL. This works, but only if you don't have '%' symbols in your URL. Also, why interfere with the user's encoding here?

There are a couple things yet to do (look at hash history which I'm not using, cleanup commits, update readme and changes), but I thought I'd run this by you all first.