### PR TITLE
Fix logic issue creating duplicate listeners

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## HEAD
+- Fix a bug causing DOM listeners to be attached multiple times
+
+[#623]: https://github.com/ReactTraining/history/pull/623 
+
 ## [v4.6.3]
 > Jun 20, 2017
 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -262,15 +262,21 @@ const createBrowserHistory = (props = {}) => {
 
   let listenerCount = 0;
 
-  const checkDOMListeners = delta => {
-    listenerCount += delta;
-
-    if (listenerCount === 1) {
-      window.addEventListener(PopStateEvent, handlePopState);
+  const incrementDomListenerCount = () => {
+    if (listenerCount === 0) {
+        window.addEventListener(PopStateEvent, handlePopState);
 
       if (needsHashChangeListener)
         window.addEventListener(HashChangeEvent, handleHashChange);
-    } else if (listenerCount === 0) {
+    }
+
+    listenerCount++;
+  };
+
+  const decrementDomListenerCount = () => {
+    listenerCount--;
+
+    if (listenerCount === 0) {
       window.removeEventListener(PopStateEvent, handlePopState);
 
       if (needsHashChangeListener)
@@ -284,14 +290,14 @@ const createBrowserHistory = (props = {}) => {
     const unblock = transitionManager.setPrompt(prompt);
 
     if (!isBlocked) {
-      checkDOMListeners(1);
+      incrementDomListenerCount();
       isBlocked = true;
     }
 
     return () => {
       if (isBlocked) {
         isBlocked = false;
-        checkDOMListeners(-1);
+        decrementDomListenerCount();
       }
 
       return unblock();
@@ -300,10 +306,10 @@ const createBrowserHistory = (props = {}) => {
 
   const listen = listener => {
     const unlisten = transitionManager.appendListener(listener);
-    checkDOMListeners(1);
+    incrementDomListenerCount();
 
     return () => {
-      checkDOMListeners(-1);
+      decrementDomListenerCount();
       unlisten();
     };
   };

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -287,12 +287,18 @@ const createHashHistory = (props = {}) => {
 
   let listenerCount = 0;
 
-  const checkDOMListeners = delta => {
-    listenerCount += delta;
-
-    if (listenerCount === 1) {
+  const incrementDomListenerCount = () => {
+    if (listenerCount === 0) {
       window.addEventListener(HashChangeEvent, handleHashChange);
-    } else if (listenerCount === 0) {
+    }
+
+    listenerCount++;
+  };
+
+  const decrementDomListenerCount = () => {
+    listenerCount--;
+
+    if (listenerCount === 0) {
       window.removeEventListener(HashChangeEvent, handleHashChange);
     }
   };
@@ -303,14 +309,14 @@ const createHashHistory = (props = {}) => {
     const unblock = transitionManager.setPrompt(prompt);
 
     if (!isBlocked) {
-      checkDOMListeners(1);
+      incrementDomListenerCount();
       isBlocked = true;
     }
 
     return () => {
       if (isBlocked) {
         isBlocked = false;
-        checkDOMListeners(-1);
+        decrementDomListenerCount();
       }
 
       return unblock();
@@ -319,10 +325,10 @@ const createHashHistory = (props = {}) => {
 
   const listen = listener => {
     const unlisten = transitionManager.appendListener(listener);
-    checkDOMListeners(1);
+    incrementDomListenerCount();
 
     return () => {
-      checkDOMListeners(-1);
+      decrementDomListenerCount();
       unlisten();
     };
   };


### PR DESCRIPTION
@timdorr there's a bug in the logic in creating DOM listeners, currently if you attach two listeners and remove one, you'll have 1 listener, so in both browser and hash histories, it'll attach the listeners a second time.