### PR TITLE
Add documentation for unregistering listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ Locations may also have the following properties:
 
 The `action` is one of `PUSH`, `REPLACE`, or `POP` depending on how the user got to the current URL.
 
+#### Cleaning up
+When you attach a listener using `history.listen`, it returns a function that can be used to remove the listener, which can then be invoked in cleanup logic:
+
+```js
+const unlisten = history.listen(myListener);
+// ...
+unlisten();
+```
+
 ### Navigation
 
 `history` objects may be used to programmatically change the current location using the following methods:


### PR DESCRIPTION
## Motivation
We've got some wonky logic in our React app that means that we want to listen for `POP`s. `history` provides this! It's great! But you generally want to clean up listeners when they're no longer needed, e.g. in `componentWillUnmount`. I found this functionality in the source code, but it wasn't documented, so I added documentation.

## Changes
* Add documentation for `unlisten`.