### PR TITLE
fix: The second param of the  allPaths/allKeys is redundant

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -183,10 +183,7 @@ function createBrowserHistory(props = {}) {
             window.location.href = href;
           } else {
             const prevIndex = allKeys.indexOf(history.location.key);
-            const nextKeys = allKeys.slice(
-              0,
-              prevIndex === -1 ? 0 : prevIndex + 1
-            );
+            const nextKeys = allKeys.slice( 0,prevIndex + 1 );
 
             nextKeys.push(location.key);
             allKeys = nextKeys;

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -210,10 +210,7 @@ function createHashHistory(props = {}) {
           pushHashPath(encodedPath);
 
           const prevIndex = allPaths.lastIndexOf(createPath(history.location));
-          const nextPaths = allPaths.slice(
-            0,
-            prevIndex === -1 ? 0 : prevIndex + 1
-          );
+          const nextPaths = allPaths.slice( 0,  prevIndex + 1 );
 
           nextPaths.push(path);
           allPaths = nextPaths;


### PR DESCRIPTION
`prevIndex === -1 ? 0 : prevIndex + 1` and `prevIndex + 1` are completely equivalent, using the latter can also reduce the code