### PR TITLE
Add basename as key on history object

### DIFF
--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -228,5 +228,10 @@ describe('a browser history', () => {
       const history = createHistory({ basename: '/prefix' });
       expect(history.location.pathname).toEqual('/');
     });
+
+    it('is available as key on history', () => {
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.basename).toEqual('/prefix');
+    });
   });
 });

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -268,5 +268,10 @@ describe('a hash history', () => {
       const history = createHistory({ basename: '/prefix' });
       expect(history.location.pathname).toEqual('/');
     });
+
+    it('is available as key on history', () => {
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.basename).toEqual('/prefix');
+    });
   });
 });

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -317,6 +317,7 @@ function createBrowserHistory(props = {}) {
     length: globalHistory.length,
     action: 'POP',
     location: initialLocation,
+    basename,
     createHref,
     push,
     replace,

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -336,6 +336,7 @@ function createHashHistory(props = {}) {
     length: globalHistory.length,
     action: 'POP',
     location: initialLocation,
+    basename,
     createHref,
     push,
     replace,


### PR DESCRIPTION
My team has built a few different React apps that live at different paths. For example:
- `example.com/users` is it's own React app
- `example.com/admin` is it's own React app

For each, the `basename` is defined at root component and I'm trying to write a shared helper to handle users "cmd + click" or "ctrl + click" that opens the URL in a new window or tab. For `Link` this is actually handled by default but my use-case is a user clicking on a `tr` element. That function looks like:
```js
const navigateOnClick = (href, history, window) => e => {
  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
    window.open(href);
  } else {
    history.push(href);
  }
};
```

The issue is that `href` will not include the basename. For the `else` case here (`history.push(href)`) this works as expected. However, for the `if` case (`window.open(href)`) it will go to the wrong URL (missing the basename). This PR just exposes `basename` on the `history` object which would allow me to do:
```js
const navigateOnClick = (href, history, window) => e => {
  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
    window.open(`${history.basename}${href}`);
  } else {
    history.push(href);
  }
};
```
so I wouldn't need to hard-code my basename which lets me reuse this helper.