### PR TITLE
Added callback to history.replace().

### DIFF
--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -87,6 +87,12 @@ describe('a browser history', () => {
       });
     });
 
+    describe('replace state with callback', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceCallback(history, done);
+      });
+    });
+
     describe('location created by encoded and unencoded pathname', () => {
       it('produces the same location.pathname', done => {
         TestSequences.LocationPathnameAlwaysSame(history, done);

--- a/modules/__tests__/TestSequences/ReplaceCallback.js
+++ b/modules/__tests__/TestSequences/ReplaceCallback.js
@@ -1,0 +1,27 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function (history, done) {
+  const replaceCallback = (newState, oldState) => ({ ...oldState, ...newState, foo: 'bar' });
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace('/home?the=query#the-hash', { the: 'state' }, replaceCallback);
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash',
+        state: { the: 'state', foo: "bar" }
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/modules/__tests__/TestSequences/index.js
+++ b/modules/__tests__/TestSequences/index.js
@@ -42,3 +42,4 @@ export {
 } from './ReturnFalseTransitionHook';
 export { default as SlashHashPathCoding } from './SlashHashPathCoding';
 export { default as TransitionHookArgs } from './TransitionHookArgs';
+export { default as ReplaceCallback } from "./ReplaceCallback";

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -60,11 +60,11 @@ function createBrowserHistory(props = {}) {
     warning(
       !basename || hasBasename(path, basename),
       'You are attempting to use a basename on a page whose URL path does not begin ' +
-        'with the basename. Expected path "' +
-        path +
-        '" to begin with "' +
-        basename +
-        '".'
+      'with the basename. Expected path "' +
+      path +
+      '" to begin with "' +
+      basename +
+      '".'
     );
 
     if (basename) path = stripBasename(path, basename);
@@ -160,7 +160,7 @@ function createBrowserHistory(props = {}) {
         state !== undefined
       ),
       'You should avoid providing a 2nd state argument to push when the 1st ' +
-        'argument is a location-like object that already has state; it is ignored'
+      'argument is a location-like object that already has state; it is ignored'
     );
 
     const action = 'PUSH';
@@ -205,7 +205,7 @@ function createBrowserHistory(props = {}) {
     );
   }
 
-  function replace(path, state) {
+  function replace(path, state, stateTransition = null) {
     warning(
       !(
         typeof path === 'object' &&
@@ -213,10 +213,13 @@ function createBrowserHistory(props = {}) {
         state !== undefined
       ),
       'You should avoid providing a 2nd state argument to replace when the 1st ' +
-        'argument is a location-like object that already has state; it is ignored'
+      'argument is a location-like object that already has state; it is ignored'
     );
 
     const action = 'REPLACE';
+    if (stateTransition) {
+      state = stateTransition(state, history.location && history.location.state);
+    }
     const location = createLocation(path, state, createKey(), history.location);
 
     transitionManager.confirmTransitionTo(

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -53,7 +53,7 @@ function createMemoryHistory(props = {}) {
         state !== undefined
       ),
       'You should avoid providing a 2nd state argument to push when the 1st ' +
-        'argument is a location-like object that already has state; it is ignored'
+      'argument is a location-like object that already has state; it is ignored'
     );
 
     const action = 'PUSH';
@@ -90,7 +90,7 @@ function createMemoryHistory(props = {}) {
     );
   }
 
-  function replace(path, state) {
+  function replace(path, state, stateTransition = null) {
     warning(
       !(
         typeof path === 'object' &&
@@ -98,10 +98,14 @@ function createMemoryHistory(props = {}) {
         state !== undefined
       ),
       'You should avoid providing a 2nd state argument to replace when the 1st ' +
-        'argument is a location-like object that already has state; it is ignored'
+      'argument is a location-like object that already has state; it is ignored'
     );
 
     const action = 'REPLACE';
+    if (stateTransition) {
+      state = stateTransition(state, history.location && history.location.state);
+    }
+
     const location = createLocation(path, state, createKey(), history.location);
 
     transitionManager.confirmTransitionTo(


### PR DESCRIPTION
Implements the feature request made in #698, specifically the idea I explained in my comment there.

I'm not entirely sure if the callback should also be added to other actions. A maintainers input either here or on the original feature request is greatly appreciated.

(Also: I can undo the white-space changes, as they create quite a lot of noise. But it's actually more consistent now)