### PR TITLE
Fixed a bug parsing URLs with both hash and search

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -26,16 +26,16 @@ export function parsePath(path) {
   let search = '';
   let hash = '';
 
-  const hashIndex = pathname.indexOf('#');
-  if (hashIndex !== -1) {
-    hash = pathname.substr(hashIndex);
-    pathname = pathname.substr(0, hashIndex);
-  }
-
   const searchIndex = pathname.indexOf('?');
   if (searchIndex !== -1) {
     search = pathname.substr(searchIndex);
     pathname = pathname.substr(0, searchIndex);
+  }
+
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex !== -1) {
+    hash = pathname.substr(hashIndex);
+    pathname = pathname.substr(0, hashIndex);
   }
 
   return {


### PR DESCRIPTION
Since # always comes before ? in a URL, the code starting "const searchIndex" should come before "const hashIndex".

Currently the URL "/#foo?bar" is parsed to { pathname: "/", hash: "#foo?bar", search: "" }, not the desired { pathname: "/", hash: "#foo", search: "?bar" }.

I am such a newbie that I don't really know how to test my patch, but I'm pretty confident that it should work.

Here is a codesandbox illustrating the problem: https://codesandbox.io/embed/failing-history-rnqzu
Add "#foo?bar" in the demo browser address bar and hit enter. Then look at the console output.

Thanks!