### PR TITLE
Update value-equal and resolve-pathname (all non-dev deps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "loose-envify": "^1.2.0",
-    "resolve-pathname": "^2.2.0",
+    "resolve-pathname": "^3.0.0",
     "tiny-invariant": "^1.0.2",
     "tiny-warning": "^1.0.0",
-    "value-equal": "^0.4.0"
+    "value-equal": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION
Tests and lints pass, and I couldn't find any backwards-compatibility-breaking announcements. Only modules/LocationUtils.js ended up using it.