### PR TITLE
ADD: install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 The history library lets you easily manage session history anywhere JavaScript runs. `history` abstracts away the differences in various environments and provides a minimal API that lets you manage the history stack, navigate, and persist state between sessions.
 
+## Install
+```console
+npm i history -S
+```
+
 ## Documentation
 
 Documentation for the current branch can be found in the [docs](docs) directory.


### PR DESCRIPTION
I find that I need to go to npm page (https://www.npmjs.com/package/history) to find the install method. It is better to have the install method
