### PR TITLE
Fix broken forceRefresh feature

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -176,11 +176,10 @@ function createBrowserHistory(props = {}) {
         const { key, state } = location;
 
         if (canUseHistory) {
-          globalHistory.pushState({ key, state }, null, href);
-
           if (forceRefresh) {
             window.location.href = href;
           } else {
+            globalHistory.pushState({ key, state }, null, href);
             const prevIndex = allKeys.indexOf(history.location.key);
             const nextKeys = allKeys.slice(0, prevIndex + 1);
 
@@ -226,11 +225,10 @@ function createBrowserHistory(props = {}) {
         const { key, state } = location;
 
         if (canUseHistory) {
-          globalHistory.replaceState({ key, state }, null, href);
-
           if (forceRefresh) {
             window.location.replace(href);
           } else {
+            globalHistory.replaceState({ key, state }, null, href);
             const prevIndex = allKeys.indexOf(history.location.key);
 
             if (prevIndex !== -1) allKeys[prevIndex] = location.key;


### PR DESCRIPTION
This is related to #639 and #638 and continues @reywright and @pshrmn proposed solution. 

__Problem:__ 
When using `createBrowserHistory` with the `forceRefresh` prop, the methods `go`, `goBack` and `goForward` do not behave as expected. The location url will update but the page does not refresh. 

__Proposed Solution:__

Update the `createBrowserHistory` behaviour for `push` and `replace` methods to not call the History api's `pushState` and `replaceState` methods when `forceRefresh` prop is true.

__Why?__ 

As stated in the original feature issue #95
> Some users need a history that:
> - has clean URLs, like browser history
> - uses full page refreshes instead of pushState

Currently `forceRefresh` does not always use full page refreshes and is still calling `pushState`. Making this change will ensure the feature adheres to its original purpose.


