### PR TITLE
Add Support for Custom Confirmation Dialogue Box

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/history.js": {
-    "bundled": 28076,
-    "minified": 12353,
-    "gzipped": 3575,
+    "bundled": 28727,
+    "minified": 12733,
+    "gzipped": 3739,
     "treeshaked": {
       "rollup": {
         "code": 208,
@@ -14,13 +14,13 @@
     }
   },
   "umd/history.js": {
-    "bundled": 33021,
-    "minified": 11943,
-    "gzipped": 3917
+    "bundled": 33414,
+    "minified": 12026,
+    "gzipped": 3985
   },
   "umd/history.min.js": {
-    "bundled": 30384,
-    "minified": 9993,
-    "gzipped": 3501
+    "bundled": 30777,
+    "minified": 10076,
+    "gzipped": 3592
   }
 }

--- a/docs/Blocking.md
+++ b/docs/Blocking.md
@@ -17,6 +17,12 @@ history.block((location, action) => {
   if (input.value !== '') return 'Are you sure you want to leave this page?';
 });
 
+// Alternatively if you set getUserConfirmation with a custom function,
+// you can pass it a config object. It will then call getUserConfirmation
+// with this config object.
+const config = {key1:1,key2:'Hello'};
+history.block(config);
+
 // To stop blocking transitions, call the function returned from block().
 unblock();
 ```

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -26,7 +26,7 @@ function createTransitionManager() {
       const result =
         typeof prompt === 'function' ? prompt(location, action) : prompt;
 
-      if (typeof result === 'string') {
+      if (typeof result === 'string' || typeof result === 'object') {
         if (typeof getUserConfirmation === 'function') {
           getUserConfirmation(result, callback);
         } else {


### PR DESCRIPTION
history.block can set the dialogue for confirmation window, but if you have multiple confirmation windows for different pages, you need to recreate the history object. This change allows you to pass a config object down to your custom getUserConfirmation function to help configure your confirmation window you show.